### PR TITLE
feat: optional static domain for callback & allow setting statecookie.domain

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	Scopes   []string        `json:"scopes"`
 
 	CallbackUri string `json:"callback_uri"`
+	// If set, use a fixed callback domain to interface with the IDP.
+	// Particularly useful when combined with StateCookie.Domain.
+	CallbackDomain string `json:"callback_domain"`
+	CallbackScheme string `json:"callback_scheme"`
 
 	// The URL used to start authorization when needed.
 	// All other requests that are not already authorized will return a 401 Unauthorized.
@@ -111,6 +115,8 @@ func CreateConfig() *Config {
 		// Maybe a traefik bug. So I've moved this to the New() method.
 		//Scopes:                []string{"openid", "profile", "email"},
 		CallbackUri:           "/oidc/callback",
+		CallbackDomain:        "",
+		CallbackScheme:        "",
 		LogoutUri:             "/logout",
 		PostLogoutRedirectUri: "/",
 		StateCookie: &StateCookieConfig{

--- a/config.go
+++ b/config.go
@@ -73,6 +73,7 @@ type ProviderConfig struct {
 type StateCookieConfig struct {
 	Name     string `json:"name"`
 	Path     string `json:"path"`
+	Domain   string `json:"domain"`
 	Secure   bool   `json:"secure"`
 	HttpOnly bool   `json:"http_only"`
 	SameSite string `json:"same_site"`
@@ -115,6 +116,7 @@ func CreateConfig() *Config {
 		StateCookie: &StateCookieConfig{
 			Name:     "Authorization",
 			Path:     "/",
+			Domain:   "",
 			Secure:   true,
 			HttpOnly: true,
 			SameSite: "default",
@@ -177,6 +179,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 
 	log(config.LogLevel, LogLevelInfo, "Configuration loaded. Provider Url: %v", parsedURL)
 	log(config.LogLevel, LogLevelDebug, "Scopes: %s", strings.Join(config.Scopes, ", "))
+	log(config.LogLevel, LogLevelDebug, "StateCookie: %v", config.StateCookie)
 
 	return &TraefikOidcAuth{
 		next:           next,

--- a/config.go
+++ b/config.go
@@ -33,15 +33,10 @@ type Config struct {
 
 	// Can be a relative path or a full URL.
 	// If a relative path is used, the scheme and domain will be taken from the incoming request.
-	// In this case, the callback path will overlay any wrapped services.
-	// If a full URL is used, the scheme and domain will be taken from the URL, and all callbacks
-	// routed there.  It is the user's responsibility to ensure that the callback URL is also routed
-	// to this plugin.
+	// In this case, the callback path will overlay all hostnames behind the middleware.
+	// If a full URL is used, all callbacks are sent there.  It is the user's responsibility to ensure
+	// that the callback URL is also routed to this middleware plugin.
 	CallbackUri string `json:"callback_uri"`
-	// If set, use a fixed callback domain to interface with the IDP.
-	// Particularly useful when combined with StateCookie.Domain.
-	CallbackDomain string `json:"callback_domain"`
-	CallbackScheme string `json:"callback_scheme"`
 
 	// The URL used to start authorization when needed.
 	// All other requests that are not already authorized will return a 401 Unauthorized.

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func (toa *TraefikOidcAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 			ok = isValid
 
 			if ok && claims != nil {
+				log(toa.Config.LogLevel, LogLevelDebug, "Claims: %+v", claims)
 				for _, claimMap := range toa.Config.Headers.MapClaims {
 					for claimName, claimValue := range claims {
 						if claimName == claimMap.Claim {

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func (toa *TraefikOidcAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		return
 	}
 
-	if strings.HasPrefix(req.RequestURI, toa.Config.CallbackUri) && (toa.Config.CallbackDomain == "" || toa.CallbackUriAbsolute(req) == ensureAbsoluteUrl(req, req.RequestURI)) {
+	if strings.HasPrefix(req.RequestURI, toa.Config.CallbackUri) && (toa.Config.CallbackDomain == "" || strings.HasPrefix(ensureAbsoluteUrl(req, req.RequestURI), toa.CallbackUriAbsolute(req))) {
 		toa.handleCallback(rw, req)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ func (toa *TraefikOidcAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 				Name:    toa.Config.StateCookie.Name,
 				Value:   "",
 				Path:    toa.Config.StateCookie.Path,
+				Domain:  toa.Config.StateCookie.Domain,
 				Expires: time.Now().Add(-24 * time.Hour),
 				MaxAge:  -1,
 			})
@@ -418,6 +419,7 @@ func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http
 		}
 
 		// TODO: Make configurable
+		// TODO does this need domain tweaks?
 		http.SetCookie(rw, &http.Cookie{
 			Name:     "CodeVerifier",
 			Value:    encryptedCodeVerifier,
@@ -464,6 +466,7 @@ func (toa *TraefikOidcAuth) SetChunkedCookies(rw http.ResponseWriter, cookieName
 			Secure:   toa.Config.StateCookie.Secure,
 			HttpOnly: toa.Config.StateCookie.HttpOnly,
 			Path:     toa.Config.StateCookie.Path,
+			Domain:   toa.Config.StateCookie.Domain,
 			SameSite: parseCookieSameSite(toa.Config.StateCookie.SameSite),
 		})
 	} else {
@@ -473,6 +476,7 @@ func (toa *TraefikOidcAuth) SetChunkedCookies(rw http.ResponseWriter, cookieName
 			Secure:   toa.Config.StateCookie.Secure,
 			HttpOnly: toa.Config.StateCookie.HttpOnly,
 			Path:     toa.Config.StateCookie.Path,
+			Domain:   toa.Config.StateCookie.Domain,
 			SameSite: parseCookieSameSite(toa.Config.StateCookie.SameSite),
 		})
 
@@ -483,6 +487,7 @@ func (toa *TraefikOidcAuth) SetChunkedCookies(rw http.ResponseWriter, cookieName
 				Secure:   toa.Config.StateCookie.Secure,
 				HttpOnly: toa.Config.StateCookie.HttpOnly,
 				Path:     toa.Config.StateCookie.Path,
+				Domain:   toa.Config.StateCookie.Domain,
 				SameSite: parseCookieSameSite(toa.Config.StateCookie.SameSite),
 			})
 		}
@@ -540,6 +545,7 @@ func (toa *TraefikOidcAuth) ClearChunkedCookie(rw http.ResponseWriter, req *http
 			Name:    cookieName,
 			Value:   "",
 			Path:    toa.Config.StateCookie.Path,
+			Domain:  toa.Config.StateCookie.Domain,
 			Expires: time.Now().Add(-24 * time.Hour),
 			MaxAge:  -1,
 		})
@@ -548,6 +554,7 @@ func (toa *TraefikOidcAuth) ClearChunkedCookie(rw http.ResponseWriter, req *http
 			Name:    fmt.Sprintf("%sChunks", cookieName),
 			Value:   "",
 			Path:    toa.Config.StateCookie.Path,
+			Domain:  toa.Config.StateCookie.Domain,
 			Expires: time.Now().Add(-24 * time.Hour),
 			MaxAge:  -1,
 		})
@@ -557,6 +564,7 @@ func (toa *TraefikOidcAuth) ClearChunkedCookie(rw http.ResponseWriter, req *http
 				Name:    fmt.Sprintf("%s%d", cookieName, i+1),
 				Value:   "",
 				Path:    toa.Config.StateCookie.Path,
+				Domain:  toa.Config.StateCookie.Domain,
 				Expires: time.Now().Add(-24 * time.Hour),
 				MaxAge:  -1,
 			})

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 type TraefikOidcAuth struct {
 	next              http.Handler
 	ProviderURL       *url.URL
+	CallbackURL       *url.URL
 	Config            *Config
 	SessionStorage    SessionStorage
 	DiscoveryDocument *OidcDiscovery
@@ -62,6 +63,16 @@ func (toa *TraefikOidcAuth) EnsureOidcDiscovery() error {
 	}
 
 	return nil
+}
+
+func (toa *TraefikOidcAuth) CallbackURLAbsolute(req *http.Request) *url.URL {
+	if toa.CallbackURL.Host == "" || toa.CallbackURL.Scheme == "" {
+		abs := *toa.CallbackURL
+		abs.Scheme = req.URL.Scheme
+		abs.Host = req.URL.Host
+		return &abs
+	}
+	return toa.CallbackURL
 }
 
 func (toa *TraefikOidcAuth) CallbackUriAbsolute(req *http.Request) string {

--- a/main.go
+++ b/main.go
@@ -301,6 +301,7 @@ func (toa *TraefikOidcAuth) handleCallback(rw http.ResponseWriter, req *http.Req
 			Secure:   true,
 			HttpOnly: true,
 			Path:     toa.Config.CallbackUri,
+			Domain:   toa.Config.CallbackDomain,
 			SameSite: http.SameSiteDefaultMode,
 		})
 
@@ -434,6 +435,7 @@ func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http
 			Secure:   true,
 			HttpOnly: true,
 			Path:     toa.Config.CallbackUri,
+			Domain:   toa.Config.CallbackDomain,
 			SameSite: http.SameSiteDefaultMode,
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -66,13 +66,14 @@ func (toa *TraefikOidcAuth) EnsureOidcDiscovery() error {
 }
 
 func (toa *TraefikOidcAuth) CallbackURLAbsolute(req *http.Request) *url.URL {
-	if toa.CallbackURL.Host == "" || toa.CallbackURL.Scheme == "" {
+	if urlIsAbsolute(toa.CallbackURL) {
+		return toa.CallbackURL
+	} else {
 		abs := *toa.CallbackURL
 		abs.Scheme = req.URL.Scheme
 		abs.Host = req.URL.Host
 		return &abs
 	}
-	return toa.CallbackURL
 }
 
 func (toa *TraefikOidcAuth) CallbackUriAbsolute(req *http.Request) string {

--- a/oidc.go
+++ b/oidc.go
@@ -166,7 +166,7 @@ func randomBytesInHex(count int) (string, error) {
 }
 
 func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode string) (*OidcTokenResponse, error) {
-	redirectUrl := oidcAuth.CallbackUriAbsolute(req)
+	redirectUrl := oidcAuth.CallbackURLAbsolute(req).String()
 
 	urlValues := url.Values{
 		"grant_type":   {"authorization_code"},

--- a/oidc.go
+++ b/oidc.go
@@ -166,9 +166,7 @@ func randomBytesInHex(count int) (string, error) {
 }
 
 func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode string) (*OidcTokenResponse, error) {
-	host := getFullHost(req)
-
-	redirectUrl := host + oidcAuth.Config.CallbackUri
+	redirectUrl := oidcAuth.CallbackUriAbsolute(req)
 
 	urlValues := url.Values{
 		"grant_type":   {"authorization_code"},

--- a/oidc.go
+++ b/oidc.go
@@ -166,7 +166,7 @@ func randomBytesInHex(count int) (string, error) {
 }
 
 func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode string) (*OidcTokenResponse, error) {
-	redirectUrl := oidcAuth.CallbackURLAbsolute(req).String()
+	redirectUrl := oidcAuth.GetAbsoluteCallbackURL(req).String()
 
 	urlValues := url.Values{
 		"grant_type":   {"authorization_code"},

--- a/utils.go
+++ b/utils.go
@@ -42,6 +42,12 @@ func parseCookieSameSite(sameSite string) http.SameSite {
 	}
 }
 
+func makeCookieExpireImmediately(cookie *http.Cookie) *http.Cookie {
+	cookie.Expires = time.Now().Add(-24 * time.Hour)
+	cookie.MaxAge = -1
+	return cookie
+}
+
 func parseUrl(rawUrl string) (*url.URL, error) {
 	if rawUrl == "" {
 		return nil, errors.New("invalid empty url")

--- a/utils.go
+++ b/utils.go
@@ -69,10 +69,8 @@ func parseUrl(rawUrl string) (*url.URL, error) {
 	return u, nil
 }
 
-func fillHostSchemeFromRequest(req *http.Request, u *url.URL) *url.URL {
+func getSchemeFromRequest(req *http.Request) string {
 	scheme := req.Header.Get("X-Forwarded-Proto")
-	host := req.Header.Get("X-Forwarded-Host")
-
 	if scheme == "" {
 		if req.TLS != nil {
 			scheme = "https"
@@ -80,6 +78,12 @@ func fillHostSchemeFromRequest(req *http.Request, u *url.URL) *url.URL {
 			scheme = "http"
 		}
 	}
+	return scheme
+}
+
+func fillHostSchemeFromRequest(req *http.Request, u *url.URL) *url.URL {
+	scheme := getSchemeFromRequest(req)
+	host := req.Header.Get("X-Forwarded-Host")
 	if host == "" {
 		host = req.Host
 	}
@@ -89,16 +93,8 @@ func fillHostSchemeFromRequest(req *http.Request, u *url.URL) *url.URL {
 }
 
 func getFullHost(req *http.Request) string {
-	scheme := req.Header.Get("X-Forwarded-Proto")
+	scheme := getSchemeFromRequest(req)
 	host := req.Header.Get("X-Forwarded-Host")
-
-	if scheme == "" {
-		if req.TLS != nil {
-			scheme = "https"
-		} else {
-			scheme = "http"
-		}
-	}
 	if host == "" {
 		host = req.Host
 	}

--- a/utils.go
+++ b/utils.go
@@ -48,6 +48,10 @@ func makeCookieExpireImmediately(cookie *http.Cookie) *http.Cookie {
 	return cookie
 }
 
+func urlIsAbsolute(u *url.URL) bool {
+	return u.Scheme != "" && u.Host != ""
+}
+
 func parseUrl(rawUrl string) (*url.URL, error) {
 	if rawUrl == "" {
 		return nil, errors.New("invalid empty url")

--- a/utils.go
+++ b/utils.go
@@ -69,6 +69,25 @@ func parseUrl(rawUrl string) (*url.URL, error) {
 	return u, nil
 }
 
+func fillHostSchemeFromRequest(req *http.Request, u *url.URL) *url.URL {
+	scheme := req.Header.Get("X-Forwarded-Proto")
+	host := req.Header.Get("X-Forwarded-Host")
+
+	if scheme == "" {
+		if req.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	if host == "" {
+		host = req.Host
+	}
+	u.Scheme = scheme
+	u.Host = host
+	return u
+}
+
 func getFullHost(req *http.Request) string {
 	scheme := req.Header.Get("X-Forwarded-Proto")
 	host := req.Header.Get("X-Forwarded-Host")

--- a/website/docs/getting-started/callback-uri.md
+++ b/website/docs/getting-started/callback-uri.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 4
+---
+
+# Callback URLs
+
+The `CallbackUri` field of the top-level [plugin config block](./middleware-configuration.md#plugin-config-block) can be either an absolute or relative URL.
+
+## Relative URL (the default)
+
+If configured as a relative URL (by default, `/oidc/callback`), then the plugin will intercept calls to that path under any hostname it is given.
+
+When authentication is needed, whatever host the user is accessing will be used as the callback URL for the redirect to the identity provider.
+
+When the plugin is protecting only one hostname, this is zero-configuration.
+
+If you protect many different hostnames using the plugin, it's likely desirable to use an identity provider with dynamic callback URL patterns, or to instead use the plugin in absolute URL mode.
+
+## Absolute URL
+
+If `CallbackUri` is an absolute URL with a protocol scheme and a hostname, for example `https://login.example.com/oidc/callback`, then the plugin will only intercept calls to that path and hostname, and, that URL will always be used as the callback URL for the redirect to the identity provider.
+
+This will likely greatly simplify your identity provider configuration.
+
+Of course you must pick an absolute URL where the plugin will receive the traffic.
+
+For users familiar with [thomseddon/traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth), this is equivalent to its [Auth Host Mode](https://github.com/thomseddon/traefik-forward-auth?tab=readme-ov-file#auth-host-mode).
+
+If you are protecting many different subdomains that share parent domain (for example `example.com`), you might wish to store the cookie at the common level:
+
+```yml
+  middlewares:
+    oidc-auth:
+      plugin:
+        traefik-oidc-auth:
+        # highlight-start
+          CallbackUri: "https://login.example.com/oidc/callback"
+          StateCookie:
+            Domain: ".example.com"
+        # highlight-end
+          Provider:
+            Url: "https://ident.example.com/"
+            ClientId: "<YourClientId>"
+            ClientSecret: "<YourClientSecret>"
+          Scopes: ["openid", "profile", "email"]
+```
+
+This is not required, but is a performance optimization.

--- a/website/docs/getting-started/callback-uri.md
+++ b/website/docs/getting-started/callback-uri.md
@@ -24,6 +24,8 @@ This will likely greatly simplify your identity provider configuration.
 
 Of course you must pick an absolute URL where the plugin will receive the traffic.
 
+Warning: **absolute callback URLs are incompatible with PKCE**.  See [GH-42](https://github.com/sevensolutions/traefik-oidc-auth/issues/42).
+
 For users familiar with [thomseddon/traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth), this is equivalent to its [Auth Host Mode](https://github.com/thomseddon/traefik-forward-auth?tab=readme-ov-file#auth-host-mode).
 
 If you are protecting many different subdomains that share parent domain (for example `example.com`), you might wish to store the cookie at the common level:

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -11,7 +11,7 @@ sidebar_position: 3
 | Secret | no | `string` | `MLFs4TT99kOOq8h3UAVRtYoCTDYXiRcZ`| A secret used for encryption. Must be a 32 character string. It is strongly suggested to change this. |
 | Provider | yes | [`Provider`](#provider) | *none* | Identity Provider Configuration. See *Provider* block. |
 | Scopes | no | `string[]` | `["openid", "profile", "email"]` | A list of scopes to request from the IDP. |
-| CallbackUri | no | `string` | `/oidc/callback` | Defines the callback url used by the IDP. This needs to be registered in your IDP. |
+| CallbackUri | no | `string` | `/oidc/callback` | Defines the callback url used by the IDP. This needs to be registered in your IDP. This may be either a relative URL or an absolute URL -- see also [Callback URLs](./callback-uri.md) |
 | LoginUri | no | `string` | *none* | An optional url, which should trigger the login-flow. By default every url triggers a login-flow, if the user is not already logged in. If you set this to eg. `/login`, only this url will trigger a login-flow while all other requests return *Unauthorized*.  |
 | PostLoginRedirectUri | no | `string` | *none* | An optional static redirect url where the user should be redirected after login. By default the user will be redirected to the url which triggered the login-flow. |
 | LogoutUri | no | `string` | `/logout` | The url which should trigger a logout-flow. |


### PR DESCRIPTION
* Make configurable a static domain (+scheme) when computing the callback URL
* Make configurable the StateCookie's domain name

This allows a particularly useful combination when you're running many apps in subdomains of yourdomain.com:
* Set the cookie's Domain to yourdomain.com
* Use auth.yourdomain.com as your fixed callback URL

This lets you use the same middleware to wrap many different backend services, but shares the cookie between all apps, and also means you only have to register a single callback URL in your IDP.