### PR TITLE
Add support for tokens in upstream headers

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"text/template"
 )
 
 const (
@@ -44,7 +45,7 @@ type Config struct {
 
 	Authorization *AuthorizationConfig `json:"authorization"`
 
-	Headers *HeadersConfig `json:"headers"`
+	Headers []HeaderConfig `json:"headers"`
 }
 
 type ProviderConfig struct {
@@ -88,13 +89,12 @@ type ClaimAssertion struct {
 	AllOf []string `json:"allOf"`
 }
 
-type HeadersConfig struct {
-	MapClaims []ClaimHeaderConfig `json:"map_claims"`
-}
+type HeaderConfig struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 
-type ClaimHeaderConfig struct {
-	Claim  string `json:"claim"`
-	Header string `json:"header"`
+	// A reference to the parsed Value-template
+	template *template.Template
 }
 
 // Will be called by traefik
@@ -120,7 +120,6 @@ func CreateConfig() *Config {
 			SameSite: "default",
 		},
 		Authorization: &AuthorizationConfig{},
-		Headers:       &HeadersConfig{},
 	}
 }
 

--- a/http.yml
+++ b/http.yml
@@ -18,11 +18,12 @@ http:
             #ValidAudience: "280538749656466235"
           Scopes: ["openid", "profile", "email"]
           Headers:
-            MapClaims:
-              - Claim: "preferred_username"
-                Header: "X-Oidc-Username"
-              - Claim: "sub"
-                Header: "X-Oidc-Subject"
+            - Name: "X-Oidc-Username"
+              Value: "{{`{{ .claims.preferred_username }}`}}"
+            - Name: "X-Oidc-Subject"
+              Value: "sub"
+            - Name: "Authorization"
+              Value: "{{`Bearer {{ .accessToken }}`}}"
           # Authorization:
           #   AssertClaims:
           #     - Name: roles


### PR DESCRIPTION
This PR adds support for sending the access tokens to the upstream service by using custom headers as described in #36. 

Please note that this will be a breaking change in the Header-configuration.
Previously, sending claim-values to the upstream was done like this:

```yml
Headers:
  MapClaims:
    - Claim: "preferred_username"
      Header: "X-Oidc-Username"
    - Claim: "sub"
      Header: "X-Oidc-Subject"
```

Which now needs to be written as:

```yml
Headers:
  - Name: "X-Oidc-Username"
    Value: "{{`{{ .claims.preferred_username }}`}}"
  - Name: "X-Oidc-Subject"
    Value: "{{`{{ .claims.sub }}`}}"
```

But in addition, this now also support sending tokens:

```yml
Headers:
  - Name: "Authorization"
    Value: "{{`Bearer {{ .accessToken }}`}}"
```