### PR TITLE
chore: improve verifying token logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func (toa *TraefikOidcAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 		toa.next.ServeHTTP(rw, req)
 		return
 	} else {
-		log(toa.Config.LogLevel, LogLevelError, "Verifying token: %s", err.Error())
+		log(toa.Config.LogLevel, LogLevelWarn, "Verifying token: %s", err.Error())
 	}
 
 	// Clear the session cookie

--- a/session.go
+++ b/session.go
@@ -29,7 +29,7 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*SessionSta
 			if ok {
 				return session, false, claims, err
 			} else {
-				return nil, false, nil, err
+				return nil, false, nil, fmt.Errorf("failed to validate token from AuthorizationHeader: %s", err.Error())
 			}
 		}
 	}
@@ -51,7 +51,7 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*SessionSta
 			if ok {
 				return session, false, claims, err
 			} else {
-				return nil, false, nil, err
+				return nil, false, nil, fmt.Errorf("failed to validate token from AuthorizationCookie: %s", err.Error())
 			}
 		}
 	}
@@ -60,7 +60,7 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*SessionSta
 	sessionTicket, err := toa.readChunkedCookie(req, toa.Config.SessionCookie.Name)
 
 	if err != nil {
-		return nil, false, nil, err
+		return nil, false, nil, fmt.Errorf("unable to read session cookie: %s", strings.TrimLeft(err.Error(), "http: "))
 	}
 
 	log(toa.Config.LogLevel, LogLevelDebug, "A session is present for the request and will be used.")
@@ -68,7 +68,7 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*SessionSta
 	session, claims, updatedSession, err := validateSessionTicket(toa, sessionTicket)
 
 	if err != nil {
-		return nil, false, claims, err
+		return nil, false, claims, fmt.Errorf("failed to validate session ticket: %s", err.Error())
 	}
 
 	return session, updatedSession != nil, claims, nil


### PR DESCRIPTION
Inspired by https://github.com/sevensolutions/traefik-oidc-auth/pull/64, an attempt to improve the verbosity of the log line that occurs most often.

Before
```log
traefik   | 2025-01-23 11:07:36 [ERROR] [traefik-oidc-auth] Verifying token: http: named cookie not present
```

After:
```log
traefik   | 2025-01-23 11:07:36 [WARN] [traefik-oidc-auth] Verifying token: unable to read session cookie: named cookie not present
```

And because this could be normal behaviour on the first visit or return, I decreased the log level from ERROR to WARN, but probably can be even reduced to INFO.