### PR TITLE
fix: panic on non-200 response from provider

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -204,7 +204,7 @@ func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode str
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		log(oidcAuth.Config.LogLevel, LogLevelError, "exchangeAuthCode: received bad HTTP response from Provider: %s", string(body))
-		return nil, err
+		return nil, errors.New("invalid status code")
 	}
 
 	tokenResponse := &OidcTokenResponse{}
@@ -332,7 +332,7 @@ func (toa *TraefikOidcAuth) renewToken(refreshToken string) (*OidcTokenResponse,
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		log(toa.Config.LogLevel, LogLevelError, "renewToken: received bad HTTP response from Provider: %s", string(body))
-		return nil, err
+		return nil, errors.New("invalid status code")
 	}
 
 	tokenResponse := &OidcTokenResponse{}


### PR DESCRIPTION
Closes https://github.com/sevensolutions/traefik-oidc-auth/issues/63. It was quite simple, eventually, both values returned were `nil` and caused panic later