### PR TITLE
chore: add Kanidm missing properties

### DIFF
--- a/jwks.go
+++ b/jwks.go
@@ -30,6 +30,7 @@ type JwksKey struct {
 	Kid string `json:"kid"`
 	Kty string `json:"kty"`
 	N   string `json:"n,omitempty"`
+	Alg string `json:"alg,omitempty"`
 	Use string `json:"use,omitempty"`
 	X   string `json:"x,omitempty"`
 	Y   string `json:"y,omitempty"`

--- a/oidc.go
+++ b/oidc.go
@@ -94,6 +94,7 @@ type OidcDiscovery struct {
 	UserinfoEncryptionEncValuesSupported                      []string       `json:"userinfo_encryption_enc_values_supported"`
 	UserinfoEndpoint                                          string         `json:"userinfo_endpoint"`
 	UserinfoSigningAlgValuesSupported                         []string       `json:"userinfo_signing_alg_values_supported"`
+	ServiceDocumentation                                      string         `json:"service_documentation"`
 }
 
 type OidcTokenResponse struct {
@@ -102,6 +103,7 @@ type OidcTokenResponse struct {
 	TokenType    string `json:"token_type"`
 	ExpiresIn    int    `json:"expires_in"`
 	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
 }
 
 type OidcIntrospectionResponse struct {


### PR DESCRIPTION
Nothing important here, just because I already compared Kanidm responses to the structures used in the plugin, thought it might be good to store them: just in case