### PR TITLE
feat: #61: Change cookie naming to use a prefix.

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	LogoutUri             string `json:"logout_uri"`
 	PostLogoutRedirectUri string `json:"post_logout_redirect_uri"`
 
+	CookieNamePrefix     string                     `json:"cookie_name_prefix"`
 	SessionCookie        *SessionCookieConfig       `json:"session_cookie"`
 	AuthorizationHeader  *AuthorizationHeaderConfig `json:"authorization_header"`
 	AuthorizationCookie  *AuthorizationCookieConfig `json:"authorization_cookie"`
@@ -89,7 +90,6 @@ type ProviderConfig struct {
 }
 
 type SessionCookieConfig struct {
-	Name     string `json:"name"`
 	Path     string `json:"path"`
 	Domain   string `json:"domain"`
 	Secure   bool   `json:"secure"`
@@ -138,8 +138,8 @@ func CreateConfig() *Config {
 		CallbackUri:           "/oidc/callback",
 		LogoutUri:             "/logout",
 		PostLogoutRedirectUri: "/",
+		CookieNamePrefix:      "TraefikOidcAuth",
 		SessionCookie: &SessionCookieConfig{
-			Name:     "Authorization",
 			Path:     "/",
 			Domain:   "",
 			Secure:   true,

--- a/main.go
+++ b/main.go
@@ -147,15 +147,17 @@ func (toa *TraefikOidcAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 }
 
 func (toa *TraefikOidcAuth) sanitizeForUpstream(req *http.Request) {
-	// Remove the session cookie from the request before forwarding
+	// Remove all internal cookies from the request before forwarding
 	keepCookies := make([]*http.Cookie, 0)
-	dontSendUpstreamCookieNames, _ := getChunkedCookieNames(req, getSessionCookieName(toa.Config))
+
 	for _, c := range req.Cookies() {
-		if _, ok := dontSendUpstreamCookieNames[c.Name]; !ok {
+		if !strings.HasPrefix(c.Name, toa.Config.CookieNamePrefix) {
 			keepCookies = append(keepCookies, c)
 		}
 	}
+
 	req.Header.Del("Cookie")
+
 	for _, c := range keepCookies {
 		req.AddCookie(c)
 	}

--- a/oidc.go
+++ b/oidc.go
@@ -180,7 +180,7 @@ func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode str
 	}
 
 	if oidcAuth.Config.Provider.UsePkce {
-		codeVerifierCookie, err := req.Cookie("CodeVerifier")
+		codeVerifierCookie, err := req.Cookie(getCodeVerifierCookieName(oidcAuth.Config))
 		if err != nil {
 			return nil, err
 		}

--- a/session.go
+++ b/session.go
@@ -57,7 +57,7 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*SessionSta
 	}
 
 	// Use SessionCookie, if present
-	sessionTicket, err := toa.readChunkedCookie(req, toa.Config.SessionCookie.Name)
+	sessionTicket, err := toa.readChunkedCookie(req, getSessionCookieName(toa.Config))
 
 	if err != nil {
 		return nil, false, nil, fmt.Errorf("unable to read session cookie: %s", strings.TrimLeft(err.Error(), "http: "))
@@ -166,12 +166,12 @@ func (toa *TraefikOidcAuth) storeSessionAndAttachCookie(session *SessionState, r
 		return
 	}
 
-	toa.setChunkedCookies(rw, toa.Config.SessionCookie.Name, encryptedSessionTicket)
+	toa.setChunkedCookies(rw, getSessionCookieName(toa.Config), encryptedSessionTicket)
 }
 
 func (toa *TraefikOidcAuth) createSessionCookie() *http.Cookie {
 	return &http.Cookie{
-		Name:     toa.Config.SessionCookie.Name,
+		Name:     getSessionCookieName(toa.Config),
 		Value:    "",
 		Secure:   toa.Config.SessionCookie.Secure,
 		HttpOnly: toa.Config.SessionCookie.HttpOnly,

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -17,6 +17,7 @@ sidebar_position: 3
 | PostLoginRedirectUri | no | `string` | *none* | An optional static redirect url where the user should be redirected after login. By default the user will be redirected to the url which triggered the login-flow. |
 | LogoutUri | no | `string` | `/logout` | The url which should trigger a logout-flow. |
 | PostLogoutRedirectUri | no | `string` | `/` | The url where the user should be redirected after logout. |
+| CookieNamePrefix | no | `string` | `TraefikOidcAuth` | Specifies the prefix for all cookie names. The final names are concatenated using dot-notation. Eg. `TraefikOidcAuth.Session`, `TraefikOidcAuth.CodeVerifier` etc. Please note that this prefix does not apply to *AuthorizationCookieConfig* where the name can be set individually. |
 | SessionCookie | no | [`SessionCookieConfig`](#session-cookie) | *none* | SessionCookie Configuration. See *SessionCookieConfig* block. |
 | AuthorizationHeader | no | [`AuthorizationHeaderConfig`](#authorization-header) | *none* | AuthorizationHeader Configuration. See *AuthorizationHeaderConfig* block. |
 | AuthorizationCookie | no | [`AuthorizationCookieConfig`](#authorization-cookie) | *none* | AuthorizationCookie Configuration. See *AuthorizationCookieConfig* block. |
@@ -51,7 +52,6 @@ sidebar_position: 3
 
 | Name | Required | Type | Default | Description |
 |---|---|---|---|---|
-| Name | no | `string` | `Authorization` | The name of the session-cookie. |
 | Path | no | `string` | `/` | The path to which the cookie should be assigned to. |
 | Domain | no | `string` | *none* | An optional domain to which the cookie should be assigned to. See [Callback URLs](./callback-uri.md) for examples. |
 | Secure | no | `bool` | `true` | Whether the cookie should be marked secure. |

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 | PostLoginRedirectUri | no | `string` | *none* | An optional static redirect url where the user should be redirected after login. By default the user will be redirected to the url which triggered the login-flow. |
 | LogoutUri | no | `string` | `/logout` | The url which should trigger a logout-flow. |
 | PostLogoutRedirectUri | no | `string` | `/` | The url where the user should be redirected after logout. |
-| CookieNamePrefix | no | `string` | `TraefikOidcAuth` | Specifies the prefix for all cookie names. The final names are concatenated using dot-notation. Eg. `TraefikOidcAuth.Session`, `TraefikOidcAuth.CodeVerifier` etc. Please note that this prefix does not apply to *AuthorizationCookieConfig* where the name can be set individually. |
+| CookieNamePrefix | no | `string` | `TraefikOidcAuth` | Specifies the prefix for all cookies used internally by the plugin. The final names are concatenated using dot-notation. Eg. `TraefikOidcAuth.Session`, `TraefikOidcAuth.CodeVerifier` etc. Please note that this prefix does not apply to *AuthorizationCookieConfig* where the name can be set individually. |
 | SessionCookie | no | [`SessionCookieConfig`](#session-cookie) | *none* | SessionCookie Configuration. See *SessionCookieConfig* block. |
 | AuthorizationHeader | no | [`AuthorizationHeaderConfig`](#authorization-header) | *none* | AuthorizationHeader Configuration. See *AuthorizationHeaderConfig* block. |
 | AuthorizationCookie | no | [`AuthorizationCookieConfig`](#authorization-cookie) | *none* | AuthorizationCookie Configuration. See *AuthorizationCookieConfig* block. |


### PR DESCRIPTION
This now implements option C of #61 but it will be a breaking change if someone already changed the cookie name.