### PR TITLE
test: e2e: print container logs on test failure

### DIFF
--- a/e2e/tests/dex/simple-login.spec.ts
+++ b/e2e/tests/dex/simple-login.spec.ts
@@ -52,6 +52,14 @@ http:
   });
 });
 
+test.afterEach("Traefik logs on test failure", async ({}, testInfo) => {
+  if (testInfo.status !== testInfo.expectedStatus) {
+    console.log(`${testInfo.title} failed, here are Traefik logs:`);
+    console.log(await dockerCompose.logs("traefik", { cwd: __dirname }));
+    console.log(await dockerCompose.logs("dex-https", { cwd: __dirname }));
+  }
+});
+
 test.afterAll("Stopping traefik", async () => {
   await dockerCompose.downAll({
     cwd: __dirname,


### PR DESCRIPTION
Very open to better ways of doing this, just hacked this in while debugging