### PR TITLE
Make PostLoginRedirectUri to support absolute uri

### DIFF
--- a/main.go
+++ b/main.go
@@ -394,9 +394,14 @@ func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http
 	if redirectUrlFromQuery := req.URL.Query().Get("redirect_uri"); toa.Config.LoginUri != "" && strings.HasPrefix(req.RequestURI, toa.Config.LoginUri) && redirectUrlFromQuery != "" {
 		redirectUrl = redirectUrlFromQuery
 	} else if toa.Config.PostLoginRedirectUri != "" {
-		host := utils.GetFullHost(req)
-		postLoginUri, _ := strings.CutPrefix(toa.Config.PostLoginRedirectUri, "/")
-		redirectUrl = fmt.Sprintf("%s/%s", host, postLoginUri)
+		parsed, parseErr := url.Parse(toa.Config.PostLoginRedirectUri)
+		if parseErr != nil && parsed.IsAbs() {
+			redirectUrl = toa.Config.PostLoginRedirectUri
+		} else {
+			host := utils.GetFullHost(req)
+			postLoginUri, _ := strings.CutPrefix(toa.Config.PostLoginRedirectUri, "/")
+			redirectUrl = fmt.Sprintf("%s/%s", host, postLoginUri)
+		}
 	} else {
 		host := utils.GetFullHost(req)
 		redirectUrl = fmt.Sprintf("%s%s", host, req.RequestURI)

--- a/main.go
+++ b/main.go
@@ -385,20 +385,6 @@ func (toa *TraefikOidcAuth) handleUnauthorized(rw http.ResponseWriter, req *http
 	}
 }
 
-func EnsureAbsoluteUrl(req *http.Request, url string) string {
-	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
-		return url
-	} else {
-		host := utils.GetFullHost(req)
-
-		if !strings.HasPrefix(url, "/") {
-			url = "/" + url
-		}
-
-		return host + url
-	}
-}
-
 func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http.Request) {
 	toa.logger.Log(logging.LevelInfo, "Redirecting to OIDC provider...")
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -72,6 +72,11 @@ func EnsureAbsoluteUrl(req *http.Request, url string) string {
 		return url
 	} else {
 		host := GetFullHost(req)
+
+		if !strings.HasPrefix(url, "/") {
+			url = "/" + url
+		}
+
 		return host + url
 	}
 }


### PR DESCRIPTION
This change should solve the issue https://github.com/sevensolutions/traefik-oidc-auth/issues/121 by allowing absolute uri in `PostLoginRedirectUri`.