### PR TITLE
TOA-133 Add support for default http proxy environmental variables

### DIFF
--- a/config.go
+++ b/config.go
@@ -308,6 +308,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 	httpTransport := &http.Transport{
 		// MaxIdleConns:    10,
 		// IdleConnTimeout: 30 * time.Second,
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: config.Provider.InsecureSkipVerifyBool,
 			RootCAs:            rootCAs,


### PR DESCRIPTION
solves #133 

I have tested this change on a server which requires http proxy for outgoing http requests.