### PR TITLE
Fix typo in kanidm docs

### DIFF
--- a/website/docs/identity-providers/kanidm.md
+++ b/website/docs/identity-providers/kanidm.md
@@ -19,7 +19,7 @@ To create or manage OAuth2 clients, you should use [kanidm client](https://kanid
    ```
 2. Update a scope map to be able to use the client within OpenID Connect (OIDC)
    ```shell
-   kanidm system oauth2 update-scope-map <client_id> <group_name> opened
+   kanidm system oauth2 update-scope-map <client_id> <group_name> openid
    ```
    You might also want to include other scopes here, e.g. `profile`, `email` or `groups`
    ```shell


### PR DESCRIPTION
Hi,

In the kanidm docs there was a typo where one should add the `opened` claim but it should be the `openid` claim