### PR TITLE
Fix Keycloak URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A traefik Plugin for securing the upstream service with OpenID Connect acting as
 |---|---|---|
 | [ZITADEL](https://zitadel.com/) | ✅ | |
 | [Kanidm](https://github.com/kanidm/kanidm) | ✅ | See [GH-12](https://github.com/sevensolutions/traefik-oidc-auth/issues/12) |
-| [Keycloak](https://github.com/kanidm/keycloak) | ✅ | |
+| [Keycloak](https://github.com/keycloak/keycloak) | ✅ | |
 | [Microsoft EntraID](https://learn.microsoft.com/de-de/entra/identity/) | ✅ | |
 | [HashiCorp Vault](https://www.vaultproject.io/) | ❌ | See [GH-13](https://github.com/sevensolutions/traefik-oidc-auth/issues/13) |
 | [Authentik](https://goauthentik.io/) | ✅ | |


### PR DESCRIPTION
I was a bit surprised to 404 after clicking on Keycloak :^)