### PR TITLE
docs: fix authorization.md (docker label)

### DIFF
--- a/website/docs/getting-started/authorization.md
+++ b/website/docs/getting-started/authorization.md
@@ -115,8 +115,8 @@ http:
 
 **Docker Labels**
 ```
-traefik.http.middlewares.oidc-auth.traefik-oidc-auth.provider.authorization.assertClaims[0].name=roles"
-traefik.http.middlewares.oidc-auth.traefik-oidc-auth.provider.authorization.assertClaims[0].anyOf=admin,media"
+traefik.http.middlewares.oidc-auth.traefik-oidc-auth.authorization.assertClaims[0].name=roles"
+traefik.http.middlewares.oidc-auth.traefik-oidc-auth.authorization.assertClaims[0].anyOf=admin,media"
 ```
 
 </TabItem>


### PR DESCRIPTION
I find a default in the #145 commit.
I propose to change the docs from :

```
traefik.http.middlewares.oidc-auth.traefik-oidc-auth.provider.authorization.assertClaims[0].name=roles"
traefik.http.middlewares.oidc-auth.traefik-oidc-auth.provider.authorization.assertClaims[0].anyOf=admin,media"
```
to :

```
traefik.http.middlewares.oidc-auth.traefik-oidc-auth.authorization.assertClaims[0].name=roles"
traefik.http.middlewares.oidc-auth.traefik-oidc-auth.authorization.assertClaims[0].anyOf=admin,media"
```