### PR TITLE
feat: add AlwaysCheckSession option

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -58,6 +58,9 @@ type Config struct {
 
 	BypassAuthenticationRule string `json:"bypass_authentication_rule"`
 
+	// If true, always check the session for every route
+	AlwaysCheckSession bool `json:"always_check_session"`
+
 	ErrorPages *errorPages.ErrorPagesConfig `json:"error_pages"`
 }
 
@@ -156,6 +159,7 @@ func CreateConfig() *Config {
 			Unauthenticated: &errorPages.ErrorPageConfig{},
 			Unauthorized:    &errorPages.ErrorPageConfig{},
 		},
+		AlwaysCheckSession:     false,
 	}
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -150,7 +150,10 @@ func (toa *TraefikOidcAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request)
 			session.IsAuthorized = isAuthorized(toa.logger, toa.Config.Authorization, claims)
 		}
 
-		// Ensure the session is authorized
+		// Always check authorization for every session before enforcing
+		if toa.Config.AlwaysCheckSession {
+			session.IsAuthorized = isAuthorized(toa.logger, toa.Config.Authorization, claims)
+		}
 		if !session.IsAuthorized {
 			toa.handleUnauthorized(rw, req)
 			return
@@ -446,7 +449,6 @@ func (toa *TraefikOidcAuth) handleUnauthorized(rw http.ResponseWriter, req *http
 
 func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http.Request) {
 	toa.logger.Log(logging.LevelInfo, "Redirecting to OIDC provider...")
-
 	var redirectUrl string
 
 	// If the user specified one on the /login request, use this one

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -46,6 +46,7 @@ But: If you're using YAML-files for configuration you can use [traefik's templat
 | `Headers` | no | [`Header`](#header) | *none* | Supplies a list of headers which will be attached to the upstream request. See *Header* block. |
 | `BypassAuthenticationRule`* | no | `string` | *none* | Specifies an optional rule to bypass authentication. See [Bypass Authentication Rule](./bypass-authentication-rule.md) for more details. |
 | `ErrorPages` | no | [`ErrorPages`](#error-pages) | *none* | Allows you to customize some error pages. See *ErrorPages* block. |
+| `AlwaysCheckSession` | no | `bool` | `false` |  Allow to check the session for every route.
 
 
 ## Provider Block {#provider}


### PR DESCRIPTION
AlwaysCheckSession

This feature forces a re-evaluation of a user session with each request, even if a valid session is already present.

By default, the session is reused as is. However, in scenarios where authorization rules are more advanced (such as Role-Based Access Control – RBAC) on nested paths or specific resources, the original behavior without double check can lead to certain middlewares being bypassed.

When AlwaysCheckSession is enabled, each session is checked before accessing a route. I want to clarify that only the authorization is check, and there's no need to log in again after each route.