### PR TITLE
fix: callback scheme check

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -94,10 +94,8 @@ func (toa *TraefikOidcAuth) isCallbackRequest(req *http.Request) bool {
 		return false
 	}
 
-	if utils.UrlIsAbsolute(toa.CallbackURL) {
-		if u.Scheme != toa.CallbackURL.Scheme || u.Host != toa.CallbackURL.Host {
-			return false
-		}
+	if utils.UrlIsAbsolute(toa.CallbackURL) && u.Host != toa.CallbackURL.Host {
+		return false
 	}
 
 	return true


### PR DESCRIPTION
Don't check the scheme of the callback URL when checking if a URL is the callback URL as this breaks render.com deployments.