### PR TITLE
docs: add missing `refreshToken` attribute in header template context

### DIFF
--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -138,6 +138,7 @@ By using Go-Templates you have access to the following attributes:
 |---|---|
 | `{{ .accessToken }}` | The OAuth Access Token |
 | `{{ .idToken }}` | The OAuth Id Token |
+| `{{ .refreshToken }}` | The OAuth Refresh Token |
 | `{{ .claims.* }}` | Replace `*` with the name or path to your desired claim |
 
 :::info


### PR DESCRIPTION
Refresh token is already available in header template context: https://github.com/sevensolutions/traefik-oidc-auth/blob/786ba0af4ca4d8252b32edf3c9605b59e61d16cf/src/main.go#L208

But it is undocumented, so this change adds that to the docs.

Closes #194.