### PR TITLE
feat: add `Auto` option for `UnauthorizedBehavior`

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -157,7 +157,7 @@ func CreateConfig() *Config {
 		},
 		AuthorizationHeader:  &AuthorizationHeaderConfig{},
 		AuthorizationCookie:  &AuthorizationCookieConfig{},
-		UnauthorizedBehavior: "Challenge",
+		UnauthorizedBehavior: "Auto",
 		Authorization: &AuthorizationConfig{
 			CheckOnEveryRequest: false,
 		},

--- a/src/main.go
+++ b/src/main.go
@@ -407,26 +407,48 @@ func (toa *TraefikOidcAuth) handleLogout(rw http.ResponseWriter, req *http.Reque
 }
 
 func (toa *TraefikOidcAuth) handleUnauthenticated(rw http.ResponseWriter, req *http.Request) {
-	if toa.Config.UnauthorizedBehavior == "Challenge" {
+	switch toa.Config.UnauthorizedBehavior {
+	case "Challenge":
+		// Redirect to Identity Provider
 		toa.redirectToProvider(rw, req)
-	} else {
-		data := make(map[string]interface{})
-
-		data["statusType"] = "https://tools.ietf.org/html/rfc9110#section-15.5.2"
-		data["statusCode"] = http.StatusUnauthorized
-		data["statusName"] = "Unauthorized"
-		data["description"] = "You're not authorized to access this resource. Please log in to continue."
-
-		if toa.Config.LoginUri != "" {
-			data["primaryButtonText"] = "Login"
-			data["primaryButtonUrl"] = utils.EnsureAbsoluteUrl(req, toa.Config.LoginUri)
+	case "Unauthorized":
+		// Respond with 401 Unauthorized
+		toa.writeUnauthenticatedError(rw, req)
+	case "Auto":
+		if utils.IsHtmlRequest(req) {
+			// Redirect to Identity Provider for HTML requests
+			toa.redirectToProvider(rw, req)
+		} else {
+			// Respond with 401 Unauthorized for non-HTML requests
+			toa.writeUnauthenticatedError(rw, req)
 		}
-
-		errorPages.WriteError(toa.logger, toa.Config.ErrorPages.Unauthenticated, rw, req, data)
+	default:
+		// Respond with 401 Unauthorized as a fallback
+		toa.writeUnauthenticatedError(rw, req)
 	}
 }
 
+func (toa *TraefikOidcAuth) writeUnauthenticatedError(rw http.ResponseWriter, req *http.Request) {
+	data := make(map[string]interface{})
+
+	data["statusType"] = "https://tools.ietf.org/html/rfc9110#section-15.5.2"
+	data["statusCode"] = http.StatusUnauthorized
+	data["statusName"] = "Unauthorized"
+	data["description"] = "You're not authorized to access this resource. Please log in to continue."
+
+	if toa.Config.LoginUri != "" {
+		data["primaryButtonText"] = "Login"
+		data["primaryButtonUrl"] = utils.EnsureAbsoluteUrl(req, toa.Config.LoginUri)
+	}
+
+	errorPages.WriteError(toa.logger, toa.Config.ErrorPages.Unauthenticated, rw, req, data)
+}
+
 func (toa *TraefikOidcAuth) handleUnauthorized(rw http.ResponseWriter, req *http.Request) {
+	toa.writeUnauthorizedError(rw, req)
+}
+
+func (toa *TraefikOidcAuth) writeUnauthorizedError(rw http.ResponseWriter, req *http.Request) {
 	data := make(map[string]interface{})
 
 	data["statusType"] = "https://tools.ietf.org/html/rfc9110#section-15.5.4"

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -98,6 +99,146 @@ func expectRedirectUriMatch(t *testing.T, uri string, validUris []string, should
 	}
 
 	if (shouldMatch && matchedUri != uri) || (!shouldMatch && matchedUri != "") {
+		t.Fail()
+	}
+}
+
+func TestParseAcceptType(t *testing.T) {
+	acceptType := ParseAcceptType("text/html")
+	if acceptType.Type != "text/html" {
+		t.Fail()
+	}
+	if acceptType.Weight != 1.0 {
+		t.Fail()
+	}
+
+	acceptType = ParseAcceptType("text/html;q=0.8")
+	if acceptType.Type != "text/html" {
+		t.Fail()
+	}
+	if acceptType.Weight != 0.8 {
+		t.Fail()
+	}
+
+	acceptType = ParseAcceptType("application/json; q=0.5")
+	if acceptType.Type != "application/json" {
+		t.Fail()
+	}
+	if acceptType.Weight != 0.5 {
+		t.Fail()
+	}
+
+	acceptType = ParseAcceptType("text/html;q=invalid")
+	if acceptType.Type != "" {
+		t.Fail()
+	}
+	if acceptType.Weight != 0.0 {
+		t.Fail()
+	}
+
+	acceptType = ParseAcceptType("*/*")
+	if acceptType.Type != "*/*" {
+		t.Fail()
+	}
+	if acceptType.Weight != 1.0 {
+		t.Fail()
+	}
+
+	acceptType = ParseAcceptType("")
+	if acceptType.Type != "" {
+		t.Fail()
+	}
+	if acceptType.Weight != 0.0 {
+		t.Fail()
+	}
+}
+
+func TestParseAcceptHeader(t *testing.T) {
+	acceptTypes := ParseAcceptHeader("text/html,application/json")
+	if len(acceptTypes) != 2 {
+		t.Fail()
+	}
+	if acceptTypes[0].Type != "text/html" {
+		t.Fail()
+	}
+	if acceptTypes[0].Weight != 1.0 {
+		t.Fail()
+	}
+	if acceptTypes[1].Type != "application/json" {
+		t.Fail()
+	}
+	if acceptTypes[1].Weight != 1.0 {
+		t.Fail()
+	}
+
+	acceptTypes = ParseAcceptHeader("application/json;q=0.8,text/html;q=0.9")
+	if len(acceptTypes) != 2 {
+		t.Fail()
+	}
+	if acceptTypes[0].Type != "text/html" {
+		t.Fail()
+	}
+	if acceptTypes[0].Weight != 0.9 {
+		t.Fail()
+	}
+	if acceptTypes[1].Type != "application/json" {
+		t.Fail()
+	}
+	if acceptTypes[1].Weight != 0.8 {
+		t.Fail()
+	}
+
+	acceptTypes = ParseAcceptHeader("*/*")
+	if len(acceptTypes) != 1 {
+		t.Fail()
+	}
+	if acceptTypes[0].Type != "*/*" {
+		t.Fail()
+	}
+	if acceptTypes[0].Weight != 1.0 {
+		t.Fail()
+	}
+}
+
+func TestIsHtmlRequest(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml")
+	if !IsHtmlRequest(req) {
+		t.Fail()
+	}
+
+	req, _ = http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "application/json")
+	if IsHtmlRequest(req) {
+		t.Fail()
+	}
+
+	req, _ = http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "text/html, application/json")
+	if !IsHtmlRequest(req) {
+		t.Fail()
+	}
+
+	req, _ = http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "application/json;q=0.9, text/html;q=0.8")
+	if IsHtmlRequest(req) {
+		t.Fail()
+	}
+
+	req, _ = http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "application/json;q=0.8, text/html;q=0.9")
+	if !IsHtmlRequest(req) {
+		t.Fail()
+	}
+
+	req, _ = http.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept", "*/*")
+	if IsHtmlRequest(req) {
+		t.Fail()
+	}
+
+	req, _ = http.NewRequest("GET", "/", nil)
+	if IsHtmlRequest(req) {
 		t.Fail()
 	}
 }

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -41,7 +41,7 @@ But: If you're using YAML-files for configuration you can use [traefik's templat
 | `SessionCookie` | no | [`SessionCookie`](#session-cookie) | *none* | SessionCookie Configuration. See *SessionCookieConfig* block. |
 | `AuthorizationHeader` | no | [`AuthorizationHeader`](#authorization-header) | *none* | AuthorizationHeader Configuration. See *AuthorizationHeader* block. |
 | `AuthorizationCookie` | no | [`AuthorizationCookie`](#authorization-cookie) | *none* | AuthorizationCookie Configuration. See *AuthorizationCookie* block. |
-| `UnauthorizedBehavior`* | no | `string` | `Challenge` | Defines the behavior for unauthenticated requests. `Challenge` means the user will be redirected to the IDP's login page, whereas `Unauthorized` will simply return a 401 status response. |
+| `UnauthorizedBehavior`* | no | `string` | `Auto` | Defines the behavior for unauthenticated requests. `Challenge` means the user will be redirected to the IDP's login page, `Unauthorized` will return a 401 status response, and `Auto` will automatically choose based on request type (HTML requests get redirected, AJAX requests get 401). |
 | `Authorization` | no | [`Authorization`](#authorization) | *none* | Authorization Configuration. See *Authorization* block. |
 | `Headers` | no | [`Header`](#header) | *none* | Supplies a list of headers which will be attached to the upstream request. See *Header* block. |
 | `BypassAuthenticationRule`* | no | `string` | *none* | Specifies an optional rule to bypass authentication. See [Bypass Authentication Rule](./bypass-authentication-rule.md) for more details. |


### PR DESCRIPTION
Add `Auto` option for `UnauthorizedBehavior`.

If `UnauthorizedBehavior` is `Auto`, then the HTML requests will get redirected to the Identity Provider, and other requests will get `401 Unauthorized` response.

This option is now the default one for `UnauthorizedBehavior`.

I assumed an HTML request means that there is `text/html` or `application/xhtml+xml` with the highest weight in the `Accept` header. All normal browsers will put `text/html` with the highest weight. On the other hand, AJAX requests usually will have `application/json`, `*/*` or nothing.

Note that this is pretty much my first attempt at writing Go code. So this is mostly vibe coded :stuck_out_tongue:

Feel free to treat it as some starting point and make changes yourself to adjust to whatever you want.

Closes #190.