### PR TITLE
feat: #193 keep old refresh token if IDP doesn't return a new one

### DIFF
--- a/src/session.go
+++ b/src/session.go
@@ -126,7 +126,12 @@ func validateSessionTicket(toa *TraefikOidcAuth, encryptedTicket string) (*sessi
 			}
 
 			session.AccessToken = newTokens.AccessToken
-			session.RefreshToken = newTokens.RefreshToken
+
+			if newTokens.RefreshToken != "" {
+				session.RefreshToken = newTokens.RefreshToken
+			} else {
+				toa.logger.Log(logging.LevelDebug, "The auth provider didn't return a new RefreshToken. Still keeping the old one.")
+			}
 
 			// We had some problems with some providers which didn't return a new IdToken when renewing the tokens.
 			// Thats why i'am logging this case specifically here.


### PR DESCRIPTION
Closes #193 