### PR TITLE
chore(docs): add secret to k8s example

### DIFF
--- a/website/docs/getting-started/index.md
+++ b/website/docs/getting-started/index.md
@@ -75,7 +75,8 @@ metadata:
   namespace: traefik
 type: Opaque
 stringData:
-  pluginSecret: x
+  pluginSecret: "MLFs4TT99kOOq8h3UAVRtYoCTDYXiRcZ"
+  providerClientSecret: "<YourClientSecret>"
 ---
 apiVersion: traefik.io/v1alpha1
 # highlight-next-line


### PR DESCRIPTION
I think if the secret (`Secret: "urn:k8s:secret:oidc-secret:pluginSecret"`) is referenced via urn in the k8s docs it might be nice to also give the secret as example in the code section.

Not sure if you want that to be added - just proposing here (just close MR if you do not like it in the docs - also fine for me).