### PR TITLE
docs: remove obsolete info for keycloak about audience configuration

### DIFF
--- a/website/docs/identity-providers/keycloak.md
+++ b/website/docs/identity-providers/keycloak.md
@@ -35,10 +35,5 @@ http:
             ClientId: "<YourClientId>"
             ClientSecret: "<YourClientSecret>"
             UsePkce: true
-            ValidAudience: "account"
           Scopes: ["openid", "profile", "email"]
 ```
-
-:::note
-You need to set `ValidAudience`to `account`. I don't really know why Keycloak tokens always contain the `account` audience.
-:::


### PR DESCRIPTION
Closes #240 