### PR TITLE
fix: also use jwks keys without "use" field

### DIFF
--- a/src/oidc/jwks.go
+++ b/src/oidc/jwks.go
@@ -183,7 +183,7 @@ func extractKeys(keys *JwksKeys) ([]*RsaKey, []*EcdsaKey, error) {
 	for i := 0; i < len(keys.Keys); i++ {
 		k := keys.Keys[i]
 
-		if k.Use == "sig" {
+		if k.Use == "sig" || k.Use == "" {
 			if k.Kty == "RSA" {
 				extracted, err := extractRsaKey(&k)
 


### PR DESCRIPTION
According to [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517#section-4.2 ), the field "use" is optional. Requiring jkms responses to include it reduces compatibility with implementations which rightfully exclude it.

In the spirit of being conservative in what you send and liberal in what you accept, I also submitted a [PR for Rauthy](https://github.com/sebadob/rauthy/pull/1404), which is an excellent oidc provider that does not add this field. But I think we really should also accept keys without it, hence this PR.