### PR TITLE
chore: refactor session storage

### DIFF
--- a/src/authorization.go
+++ b/src/authorization.go
@@ -6,11 +6,12 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 	"github.com/spyzhov/ajson"
 )
 
-func isAuthorized(logger *logging.Logger, authorization *AuthorizationConfig, claims map[string]interface{}) bool {
+func isAuthorized(logger *logging.Logger, authorization *config.AuthorizationConfig, claims map[string]interface{}) bool {
 	if authorization.AssertClaims != nil && len(authorization.AssertClaims) > 0 {
 		parsed, err := json.Marshal(claims)
 		if err != nil {

--- a/src/authorization_test.go
+++ b/src/authorization_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 )
 
-func createAuthInstance(claims []ClaimAssertion) *AuthorizationConfig {
-	return &AuthorizationConfig{
+func createAuthInstance(claims []config.ClaimAssertion) *config.AuthorizationConfig {
+	return &config.AuthorizationConfig{
 		AssertClaims: claims,
 	}
 }
@@ -53,7 +54,7 @@ func getTestClaims() map[string]interface{} {
 func TestClaimNameExists(t *testing.T) {
 	logger := logging.CreateLogger(logging.LevelDebug)
 	claims := getTestClaims()
-	authorization := createAuthInstance([]ClaimAssertion{
+	authorization := createAuthInstance([]config.ClaimAssertion{
 		{Name: "name"},
 	})
 
@@ -61,7 +62,7 @@ func TestClaimNameExists(t *testing.T) {
 		t.Fatal("Should authorize as a claim with the provided name exists")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "names"},
 	})
 
@@ -73,7 +74,7 @@ func TestClaimNameExists(t *testing.T) {
 func TestSimpleAssertions(t *testing.T) {
 	logger := logging.CreateLogger(logging.LevelDebug)
 	claims := getTestClaims()
-	authorization := createAuthInstance([]ClaimAssertion{
+	authorization := createAuthInstance([]config.ClaimAssertion{
 		{Name: "name", AnyOf: []string{"Alice", "Bob", "Bruno"}},
 	})
 
@@ -81,7 +82,7 @@ func TestSimpleAssertions(t *testing.T) {
 		t.Fatal("Should authorize since value is any of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "name", AnyOf: []string{"Ben", "Joe", "Sam"}},
 	})
 
@@ -89,7 +90,7 @@ func TestSimpleAssertions(t *testing.T) {
 		t.Fatal("Should not authorize since value is none of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "name", AllOf: []string{"Alice"}},
 	})
 
@@ -97,7 +98,7 @@ func TestSimpleAssertions(t *testing.T) {
 		t.Fatal("Should authorize since the single value matches all of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "name", AllOf: []string{"Alice", "Bob", "Bruno"}},
 	})
 
@@ -106,7 +107,7 @@ func TestSimpleAssertions(t *testing.T) {
 	}
 
 	// We need to use ['my:zitadel:grants'] here to escape the colons in the jsonpath.
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "['my:zitadel:grants']", AllOf: []string{"abc", "def", "ghi"}},
 	})
 
@@ -118,7 +119,7 @@ func TestSimpleAssertions(t *testing.T) {
 func TestNestedAssertions(t *testing.T) {
 	logger := logging.CreateLogger(logging.LevelDebug)
 	claims := getTestClaims()
-	authorization := createAuthInstance([]ClaimAssertion{
+	authorization := createAuthInstance([]config.ClaimAssertion{
 		{Name: "address.street", AnyOf: []string{"Freedom Rd.", "Eagle St."}},
 	})
 
@@ -126,7 +127,7 @@ func TestNestedAssertions(t *testing.T) {
 		t.Fatal("Should authorize since nested value is any of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "address.street", AnyOf: []string{"Concrete HWY"}},
 	})
 
@@ -134,7 +135,7 @@ func TestNestedAssertions(t *testing.T) {
 		t.Fatal("Should not authorize since nested value is none of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "address.street", AllOf: []string{"Freedom Rd."}},
 	})
 
@@ -142,7 +143,7 @@ func TestNestedAssertions(t *testing.T) {
 		t.Fatal("Should authorize since the single value matches all of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "address.street", AllOf: []string{"Freedom Rd.", "Eagle St."}},
 	})
 
@@ -154,7 +155,7 @@ func TestNestedAssertions(t *testing.T) {
 func TestArrayAssertions(t *testing.T) {
 	logger := logging.CreateLogger(logging.LevelDebug)
 	claims := getTestClaims()
-	authorization := createAuthInstance([]ClaimAssertion{
+	authorization := createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Bob", "Sam"}},
 	})
 
@@ -162,7 +163,7 @@ func TestArrayAssertions(t *testing.T) {
 		t.Fatal("Should authorize since some of the values are part of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Sam", "Alex"}},
 	})
 
@@ -170,7 +171,7 @@ func TestArrayAssertions(t *testing.T) {
 		t.Fatal("Should not authorize since values are none of the provided values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AllOf: []string{"Bob", "Eve"}},
 	})
 
@@ -178,7 +179,7 @@ func TestArrayAssertions(t *testing.T) {
 		t.Fatal("Should authorize since all of the provided values have a matching claim value")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AllOf: []string{"Bob", "Eve", "Alex"}},
 	})
 
@@ -190,7 +191,7 @@ func TestArrayAssertions(t *testing.T) {
 func TestCombinedAssertions(t *testing.T) {
 	logger := logging.CreateLogger(logging.LevelDebug)
 	claims := getTestClaims()
-	authorization := createAuthInstance([]ClaimAssertion{
+	authorization := createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Bob", "Sam"}, AllOf: []string{"Eve", "Bob"}},
 	})
 
@@ -198,7 +199,7 @@ func TestCombinedAssertions(t *testing.T) {
 		t.Fatal("Should authorize since both assertion quantifiers have matching values")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Bob", "Sam"}, AllOf: []string{"Eve", "Bob", "Alex"}},
 	})
 
@@ -206,7 +207,7 @@ func TestCombinedAssertions(t *testing.T) {
 		t.Fatal("Should not authorize since not all values of the allOf quantifier are matched")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Sam"}, AllOf: []string{"Eve", "Bob"}},
 	})
 
@@ -218,7 +219,7 @@ func TestCombinedAssertions(t *testing.T) {
 func TestMultipleAssertions(t *testing.T) {
 	logger := logging.CreateLogger(logging.LevelDebug)
 	claims := getTestClaims()
-	authorization := createAuthInstance([]ClaimAssertion{
+	authorization := createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Bob", "Sam"}, AllOf: []string{"Eve", "Bob"}},
 		{Name: "name", AnyOf: []string{"Alice", "Alex"}},
 	})
@@ -227,7 +228,7 @@ func TestMultipleAssertions(t *testing.T) {
 		t.Fatal("Should authorize since both assertions hold against the provided claims")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Bob", "Sam"}, AllOf: []string{"Eve", "Bob", "Alex"}},
 		{Name: "name", AnyOf: []string{"Alice", "Alex"}},
 	})
@@ -236,7 +237,7 @@ func TestMultipleAssertions(t *testing.T) {
 		t.Fatal("Should not authorize since one of the assertions does not hold")
 	}
 
-	authorization = createAuthInstance([]ClaimAssertion{
+	authorization = createAuthInstance([]config.ClaimAssertion{
 		{Name: "children[*].name", AnyOf: []string{"Joe", "Bob", "Sam"}, AllOf: []string{"Eve", "Bob", "Alex"}},
 		{Name: "name", AnyOf: []string{"Alex", "Ben"}},
 	})

--- a/src/config.go
+++ b/src/config.go
@@ -11,10 +11,10 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"text/template"
 
 	"github.com/golang-jwt/jwt/v5"
 
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/errorPages"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 	"github.com/sevensolutions/traefik-oidc-auth/src/rules"
@@ -22,126 +22,12 @@ import (
 	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
 )
 
-const DefaultSecret = "MLFs4TT99kOOq8h3UAVRtYoCTDYXiRcZ"
-
-type Config struct {
-	LogLevel string `json:"log_level"`
-
-	Secret string `json:"secret"`
-
-	Provider *ProviderConfig `json:"provider"`
-	Scopes   []string        `json:"scopes"`
-
-	// Can be a relative path or a full URL.
-	// If a relative path is used, the scheme and domain will be taken from the incoming request.
-	// In this case, the callback path will overlay all hostnames behind the middleware.
-	// If a full URL is used, all callbacks are sent there.  It is the user's responsibility to ensure
-	// that the callback URL is also routed to this middleware plugin.
-	CallbackUri string `json:"callback_uri"`
-
-	// The URL used to start authorization when needed.
-	// All other requests that are not already authorized will return a 401 Unauthorized.
-	// When left empty, all requests can start authorization.
-	LoginUri                    string   `json:"login_uri"`
-	PostLoginRedirectUri        string   `json:"post_login_redirect_uri"`
-	ValidPostLoginRedirectUris  []string `json:"valid_post_login_redirect_uris"`
-	LogoutUri                   string   `json:"logout_uri"`
-	PostLogoutRedirectUri       string   `json:"post_logout_redirect_uri"`
-	ValidPostLogoutRedirectUris []string `json:"valid_post_logout_redirect_uris"`
-
-	CookieNamePrefix     string                     `json:"cookie_name_prefix"`
-	SessionCookie        *SessionCookieConfig       `json:"session_cookie"`
-	AuthorizationHeader  *AuthorizationHeaderConfig `json:"authorization_header"`
-	AuthorizationCookie  *AuthorizationCookieConfig `json:"authorization_cookie"`
-	UnauthorizedBehavior string                     `json:"unauthorized_behavior"`
-
-	Authorization *AuthorizationConfig `json:"authorization"`
-
-	Headers []HeaderConfig `json:"headers"`
-
-	BypassAuthenticationRule string `json:"bypass_authentication_rule"`
-
-	ErrorPages *errorPages.ErrorPagesConfig `json:"error_pages"`
-
-	RequestedResources []string `json:"requested_resources"`
-}
-
-type ProviderConfig struct {
-	Url string `json:"url"`
-
-	InsecureSkipVerify     string `json:"insecure_skip_verify"`
-	InsecureSkipVerifyBool bool   `json:"insecure_skip_verify_bool"`
-
-	CABundle     string `json:"ca_bundle"`
-	CABundleFile string `json:"ca_bundle_file"`
-
-	ClientId              string `json:"client_id"`
-	ClientSecret          string `json:"client_secret"`
-	ClientJwtPrivateKey   string `json:"client_jwt_private_key"`
-	ClientJwtPrivateKeyId string `json:"client_jwt_private_key_id"`
-
-	UsePkce     string `json:"use_pkce"`
-	UsePkceBool bool   `json:"use_pkce_bool"`
-
-	ValidateAudience     string `json:"validate_audience"`
-	ValidateAudienceBool bool   `json:"validate_audience_bool"`
-	ValidAudience        string `json:"valid_audience"`
-
-	ValidateIssuer     string `json:"validate_issuer"`
-	ValidateIssuerBool bool   `json:"validate_issuer_bool"`
-	ValidIssuer        string `json:"valid_issuer"`
-
-	// AccessToken or IdToken or Introspection
-	TokenValidation string `json:"verification_token"`
-
-	TokenRenewalThreshold float64 `json:"token_renewal_threshold"`
-
-	UseClaimsFromUserInfo     string `json:"use_claims_from_user_info"`
-	UseClaimsFromUserInfoBool bool   `json:"use_claims_from_user_info_bool"`
-}
-
-type SessionCookieConfig struct {
-	Path     string `json:"path"`
-	Domain   string `json:"domain"`
-	Secure   bool   `json:"secure"`
-	HttpOnly bool   `json:"http_only"`
-	SameSite string `json:"same_site"`
-	MaxAge   int    `json:"max_age"`
-}
-
-type AuthorizationHeaderConfig struct {
-	Name string `json:"name"`
-}
-type AuthorizationCookieConfig struct {
-	Name string `json:"name"`
-}
-
-type AuthorizationConfig struct {
-	AssertClaims        []ClaimAssertion `json:"assert_claims"`
-	CheckOnEveryRequest bool             `json:"check_on_every_request"`
-}
-
-type ClaimAssertion struct {
-	Name  string   `json:"name"`
-	AnyOf []string `json:"anyOf"`
-	AllOf []string `json:"allOf"`
-}
-
-type HeaderConfig struct {
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	Values string `json:"values"`
-
-	// A reference to the parsed Value-template
-	template *template.Template
-}
-
 // Will be called by traefik
-func CreateConfig() *Config {
-	return &Config{
+func CreateConfig() *config.Config {
+	return &config.Config{
 		LogLevel: logging.LevelWarn,
-		Secret:   DefaultSecret,
-		Provider: &ProviderConfig{
+		Secret:   config.DefaultSecret,
+		Provider: &config.ProviderConfig{
 			UsePkceBool:               false,
 			InsecureSkipVerifyBool:    false,
 			ValidateIssuerBool:        true,
@@ -157,7 +43,7 @@ func CreateConfig() *Config {
 		LogoutUri:             "/logout",
 		PostLogoutRedirectUri: "/",
 		CookieNamePrefix:      "TraefikOidcAuth",
-		SessionCookie: &SessionCookieConfig{
+		SessionCookie: &config.SessionCookieConfig{
 			Path:     "/",
 			Domain:   "",
 			Secure:   true,
@@ -165,10 +51,10 @@ func CreateConfig() *Config {
 			SameSite: "default",
 			MaxAge:   0,
 		},
-		AuthorizationHeader:  &AuthorizationHeaderConfig{},
-		AuthorizationCookie:  &AuthorizationCookieConfig{},
+		AuthorizationHeader:  &config.AuthorizationHeaderConfig{},
+		AuthorizationCookie:  &config.AuthorizationCookieConfig{},
 		UnauthorizedBehavior: "Auto",
-		Authorization: &AuthorizationConfig{
+		Authorization: &config.AuthorizationConfig{
 			CheckOnEveryRequest: false,
 		},
 		ErrorPages: &errorPages.ErrorPagesConfig{
@@ -179,19 +65,19 @@ func CreateConfig() *Config {
 }
 
 // Will be called by traefik
-func New(uctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
-	config.LogLevel = utils.ExpandEnvironmentVariableString(config.LogLevel)
+func New(uctx context.Context, next http.Handler, cfg *config.Config, name string) (http.Handler, error) {
+	cfg.LogLevel = utils.ExpandEnvironmentVariableString(cfg.LogLevel)
 
-	logger := logging.CreateLogger(config.LogLevel)
+	logger := logging.CreateLogger(cfg.LogLevel)
 
 	logger.Log(logging.LevelInfo, "Loading Configuration...")
 
-	if config.Provider == nil {
+	if cfg.Provider == nil {
 		return nil, errors.New("missing provider configuration")
 	}
 
 	// Hack: Trick the traefik plugin catalog to successfully execute this method with the testData from .traefik.yml.
-	if config.Provider.Url == "https://..." {
+	if cfg.Provider.Url == "https://..." {
 		return &TraefikOidcAuth{
 			next: next,
 		}, nil
@@ -199,87 +85,87 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 
 	var err error
 
-	config.Secret = utils.ExpandEnvironmentVariableString(config.Secret)
-	config.CallbackUri = utils.ExpandEnvironmentVariableString(config.CallbackUri)
-	config.LoginUri = utils.ExpandEnvironmentVariableString(config.LoginUri)
-	config.PostLoginRedirectUri = utils.ExpandEnvironmentVariableString(config.PostLoginRedirectUri)
-	config.LogoutUri = utils.ExpandEnvironmentVariableString(config.LogoutUri)
-	config.PostLogoutRedirectUri = utils.ExpandEnvironmentVariableString(config.PostLogoutRedirectUri)
-	config.CookieNamePrefix = utils.ExpandEnvironmentVariableString(config.CookieNamePrefix)
-	config.UnauthorizedBehavior = utils.ExpandEnvironmentVariableString(config.UnauthorizedBehavior)
-	config.BypassAuthenticationRule = utils.ExpandEnvironmentVariableString(config.BypassAuthenticationRule)
-	config.Provider.Url = utils.ExpandEnvironmentVariableString(config.Provider.Url)
-	config.Provider.ClientId = utils.ExpandEnvironmentVariableString(config.Provider.ClientId)
-	config.Provider.ClientSecret = utils.ExpandEnvironmentVariableString(config.Provider.ClientSecret)
-	config.Provider.ClientJwtPrivateKeyId = utils.ExpandEnvironmentVariableString(config.Provider.ClientJwtPrivateKeyId)
-	config.Provider.ClientJwtPrivateKey = utils.ExpandEnvironmentVariableString(config.Provider.ClientJwtPrivateKey)
-	config.Provider.UsePkceBool, err = utils.ExpandEnvironmentVariableBoolean(config.Provider.UsePkce, config.Provider.UsePkceBool)
+	cfg.Secret = utils.ExpandEnvironmentVariableString(cfg.Secret)
+	cfg.CallbackUri = utils.ExpandEnvironmentVariableString(cfg.CallbackUri)
+	cfg.LoginUri = utils.ExpandEnvironmentVariableString(cfg.LoginUri)
+	cfg.PostLoginRedirectUri = utils.ExpandEnvironmentVariableString(cfg.PostLoginRedirectUri)
+	cfg.LogoutUri = utils.ExpandEnvironmentVariableString(cfg.LogoutUri)
+	cfg.PostLogoutRedirectUri = utils.ExpandEnvironmentVariableString(cfg.PostLogoutRedirectUri)
+	cfg.CookieNamePrefix = utils.ExpandEnvironmentVariableString(cfg.CookieNamePrefix)
+	cfg.UnauthorizedBehavior = utils.ExpandEnvironmentVariableString(cfg.UnauthorizedBehavior)
+	cfg.BypassAuthenticationRule = utils.ExpandEnvironmentVariableString(cfg.BypassAuthenticationRule)
+	cfg.Provider.Url = utils.ExpandEnvironmentVariableString(cfg.Provider.Url)
+	cfg.Provider.ClientId = utils.ExpandEnvironmentVariableString(cfg.Provider.ClientId)
+	cfg.Provider.ClientSecret = utils.ExpandEnvironmentVariableString(cfg.Provider.ClientSecret)
+	cfg.Provider.ClientJwtPrivateKeyId = utils.ExpandEnvironmentVariableString(cfg.Provider.ClientJwtPrivateKeyId)
+	cfg.Provider.ClientJwtPrivateKey = utils.ExpandEnvironmentVariableString(cfg.Provider.ClientJwtPrivateKey)
+	cfg.Provider.UsePkceBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Provider.UsePkce, cfg.Provider.UsePkceBool)
 	if err != nil {
 		return nil, err
 	}
-	config.Provider.UseClaimsFromUserInfoBool, err = utils.ExpandEnvironmentVariableBoolean(config.Provider.UseClaimsFromUserInfo, config.Provider.UseClaimsFromUserInfoBool)
+	cfg.Provider.UseClaimsFromUserInfoBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Provider.UseClaimsFromUserInfo, cfg.Provider.UseClaimsFromUserInfoBool)
 	if err != nil {
 		return nil, err
 	}
-	config.Provider.ValidateIssuerBool, err = utils.ExpandEnvironmentVariableBoolean(config.Provider.ValidateIssuer, config.Provider.ValidateIssuerBool)
+	cfg.Provider.ValidateIssuerBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Provider.ValidateIssuer, cfg.Provider.ValidateIssuerBool)
 	if err != nil {
 		return nil, err
 	}
-	config.Provider.ValidIssuer = utils.ExpandEnvironmentVariableString(config.Provider.ValidIssuer)
-	config.Provider.ValidateAudienceBool, err = utils.ExpandEnvironmentVariableBoolean(config.Provider.ValidateAudience, config.Provider.ValidateAudienceBool)
+	cfg.Provider.ValidIssuer = utils.ExpandEnvironmentVariableString(cfg.Provider.ValidIssuer)
+	cfg.Provider.ValidateAudienceBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Provider.ValidateAudience, cfg.Provider.ValidateAudienceBool)
 	if err != nil {
 		return nil, err
 	}
-	config.Provider.ValidAudience = utils.ExpandEnvironmentVariableString(config.Provider.ValidAudience)
-	config.Provider.InsecureSkipVerifyBool, err = utils.ExpandEnvironmentVariableBoolean(config.Provider.InsecureSkipVerify, config.Provider.InsecureSkipVerifyBool)
+	cfg.Provider.ValidAudience = utils.ExpandEnvironmentVariableString(cfg.Provider.ValidAudience)
+	cfg.Provider.InsecureSkipVerifyBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Provider.InsecureSkipVerify, cfg.Provider.InsecureSkipVerifyBool)
 	if err != nil {
 		return nil, err
 	}
 
 	var clientAssertionPrivateKey *rsa.PrivateKey
-	if config.Provider.ClientJwtPrivateKey != "" && config.Provider.ClientJwtPrivateKeyId != "" {
-		clientAssertionPrivateKey, err = jwt.ParseRSAPrivateKeyFromPEM([]byte(config.Provider.ClientJwtPrivateKey))
+	if cfg.Provider.ClientJwtPrivateKey != "" && cfg.Provider.ClientJwtPrivateKeyId != "" {
+		clientAssertionPrivateKey, err = jwt.ParseRSAPrivateKeyFromPEM([]byte(cfg.Provider.ClientJwtPrivateKey))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	config.Provider.CABundle = utils.ExpandEnvironmentVariableString(config.Provider.CABundle)
-	config.Provider.CABundleFile = utils.ExpandEnvironmentVariableString(config.Provider.CABundleFile)
-	config.Provider.TokenValidation = utils.ExpandEnvironmentVariableString(config.Provider.TokenValidation)
+	cfg.Provider.CABundle = utils.ExpandEnvironmentVariableString(cfg.Provider.CABundle)
+	cfg.Provider.CABundleFile = utils.ExpandEnvironmentVariableString(cfg.Provider.CABundleFile)
+	cfg.Provider.TokenValidation = utils.ExpandEnvironmentVariableString(cfg.Provider.TokenValidation)
 
-	config.ErrorPages.Unauthenticated.FilePath = utils.ExpandEnvironmentVariableString(config.ErrorPages.Unauthenticated.FilePath)
-	config.ErrorPages.Unauthenticated.RedirectTo = utils.ExpandEnvironmentVariableString(config.ErrorPages.Unauthenticated.RedirectTo)
-	config.ErrorPages.Unauthorized.FilePath = utils.ExpandEnvironmentVariableString(config.ErrorPages.Unauthorized.FilePath)
-	config.ErrorPages.Unauthorized.RedirectTo = utils.ExpandEnvironmentVariableString(config.ErrorPages.Unauthorized.RedirectTo)
+	cfg.ErrorPages.Unauthenticated.FilePath = utils.ExpandEnvironmentVariableString(cfg.ErrorPages.Unauthenticated.FilePath)
+	cfg.ErrorPages.Unauthenticated.RedirectTo = utils.ExpandEnvironmentVariableString(cfg.ErrorPages.Unauthenticated.RedirectTo)
+	cfg.ErrorPages.Unauthorized.FilePath = utils.ExpandEnvironmentVariableString(cfg.ErrorPages.Unauthorized.FilePath)
+	cfg.ErrorPages.Unauthorized.RedirectTo = utils.ExpandEnvironmentVariableString(cfg.ErrorPages.Unauthorized.RedirectTo)
 
-	if config.Secret == DefaultSecret {
+	if cfg.Secret == config.DefaultSecret {
 		logger.Log(logging.LevelWarn, "You're using the default secret! It is highly recommended to change the secret by specifying a random 32 character value using the Secret-option.")
 	}
 
-	secret := []byte(config.Secret)
+	secret := []byte(cfg.Secret)
 	if len(secret) != 32 {
 		logger.Log(logging.LevelError, "Invalid secret provided. Secret must be exactly 32 characters in length. The provided secret has %d characters.", len(secret))
 		return nil, errors.New("invalid secret")
 	}
 
-	if config.Provider.CABundle != "" && config.Provider.CABundleFile != "" {
+	if cfg.Provider.CABundle != "" && cfg.Provider.CABundleFile != "" {
 		logger.Log(logging.LevelError, "You can only use an inline CABundle OR CABundleFile, not both.")
 		return nil, errors.New("you can only use an inline CABundle OR CABundleFile, not both.")
 	}
 
 	// Specify default scopes if not provided
-	if config.Scopes == nil || len(config.Scopes) == 0 {
-		config.Scopes = []string{"openid", "profile", "email"}
+	if cfg.Scopes == nil || len(cfg.Scopes) == 0 {
+		cfg.Scopes = []string{"openid", "profile", "email"}
 	}
 
-	parsedURL, err := utils.ParseUrl(config.Provider.Url)
+	parsedURL, err := utils.ParseUrl(cfg.Provider.Url)
 	if err != nil {
 		logger.Log(logging.LevelError, "Error while parsing Provider.Url: %s", err.Error())
 		return nil, err
 	}
 
-	parsedCallbackURL, err := url.Parse(config.CallbackUri)
+	parsedCallbackURL, err := url.Parse(cfg.CallbackUri)
 	if err != nil {
 		logger.Log(logging.LevelError, "Error while parsing CallbackUri: %s", err.Error())
 		return nil, err
@@ -292,17 +178,17 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 	} else {
 		logger.Log(logging.LevelInfo, "Callback URL is relative, will overlay any wrapped host")
 	}
-	logger.Log(logging.LevelDebug, "Scopes: %s", strings.Join(config.Scopes, ", "))
-	logger.Log(logging.LevelDebug, "SessionCookie: %v", config.SessionCookie)
+	logger.Log(logging.LevelDebug, "Scopes: %s", strings.Join(cfg.Scopes, ", "))
+	logger.Log(logging.LevelDebug, "SessionCookie: %v", cfg.SessionCookie)
 
-	if config.Provider.TokenRenewalThreshold < 0.5 || config.Provider.TokenRenewalThreshold > 1.0 {
+	if cfg.Provider.TokenRenewalThreshold < 0.5 || cfg.Provider.TokenRenewalThreshold > 1.0 {
 		logger.Log(logging.LevelError, "Invalid TokenRenewalThreshold. The value must be >= 0.5 and <= 1.0.")
 		return nil, errors.New("invalid TokenRenewalThreshold")
 	}
 
 	var conditionalAuth *rules.RequestCondition
-	if config.BypassAuthenticationRule != "" {
-		ca, err := rules.ParseRequestCondition(config.BypassAuthenticationRule)
+	if cfg.BypassAuthenticationRule != "" {
+		ca, err := rules.ParseRequestCondition(cfg.BypassAuthenticationRule)
 
 		if err != nil {
 			return nil, err
@@ -318,26 +204,26 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 
 	var caBundleData []byte
 
-	if config.Provider.CABundle != "" {
-		if strings.HasPrefix(config.Provider.CABundle, "base64:") {
-			caBundleData, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(config.Provider.CABundle, "base64:"))
+	if cfg.Provider.CABundle != "" {
+		if strings.HasPrefix(cfg.Provider.CABundle, "base64:") {
+			caBundleData, err = base64.StdEncoding.DecodeString(strings.TrimPrefix(cfg.Provider.CABundle, "base64:"))
 			if err != nil {
 				logger.Log(logging.LevelInfo, "Failed to base64-decode the inline CA bundle")
 				return nil, err
 			}
 		} else {
-			caBundleData = []byte(config.Provider.CABundle)
+			caBundleData = []byte(cfg.Provider.CABundle)
 		}
 
 		logger.Log(logging.LevelDebug, "Loaded CA bundle provided inline")
-	} else if config.Provider.CABundleFile != "" {
-		caBundleData, err = os.ReadFile(config.Provider.CABundleFile)
+	} else if cfg.Provider.CABundleFile != "" {
+		caBundleData, err = os.ReadFile(cfg.Provider.CABundleFile)
 		if err != nil {
-			logger.Log(logging.LevelInfo, "Failed to load CA bundle from %v: %v", config.Provider.CABundleFile, err)
+			logger.Log(logging.LevelInfo, "Failed to load CA bundle from %v: %v", cfg.Provider.CABundleFile, err)
 			return nil, err
 		}
 
-		logger.Log(logging.LevelDebug, "Loaded CA bundle from %v", config.Provider.CABundleFile)
+		logger.Log(logging.LevelDebug, "Loaded CA bundle from %v", cfg.Provider.CABundleFile)
 	}
 
 	if caBundleData != nil {
@@ -348,7 +234,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 
 	}
 
-	for _, header := range config.Headers {
+	for _, header := range cfg.Headers {
 		if header.Value != "" && header.Values != "" {
 			logger.Log(logging.LevelError, "Invalid Header: you can only use one of Value or Values, not both")
 			return nil, errors.New("invalid Header")
@@ -360,7 +246,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		// IdleConnTimeout: 30 * time.Second,
 		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: config.Provider.InsecureSkipVerifyBool,
+			InsecureSkipVerify: cfg.Provider.InsecureSkipVerifyBool,
 			RootCAs:            rootCAs,
 		},
 	}
@@ -378,7 +264,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		ProviderURL:              parsedURL,
 		ClientJwtPrivateKey:      clientAssertionPrivateKey,
 		CallbackURL:              parsedCallbackURL,
-		Config:                   config,
+		Config:                   cfg,
 		SessionStorage:           session.CreateCookieSessionStorage(),
 		BypassAuthenticationRule: conditionalAuth,
 	}, nil

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"text/template"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/errorPages"
+)
+
+const DefaultSecret = "MLFs4TT99kOOq8h3UAVRtYoCTDYXiRcZ"
+
+const (
+	SessionStorageTypeCookie string = "Cookie"
+)
+
+type Config struct {
+	LogLevel string `json:"log_level"`
+
+	Secret string `json:"secret"`
+
+	Provider *ProviderConfig `json:"provider"`
+	Scopes   []string        `json:"scopes"`
+
+	// Can be a relative path or a full URL.
+	// If a relative path is used, the scheme and domain will be taken from the incoming request.
+	// In this case, the callback path will overlay all hostnames behind the middleware.
+	// If a full URL is used, all callbacks are sent there.  It is the user's responsibility to ensure
+	// that the callback URL is also routed to this middleware plugin.
+	CallbackUri string `json:"callback_uri"`
+
+	// The URL used to start authorization when needed.
+	// All other requests that are not already authorized will return a 401 Unauthorized.
+	// When left empty, all requests can start authorization.
+	LoginUri                    string   `json:"login_uri"`
+	PostLoginRedirectUri        string   `json:"post_login_redirect_uri"`
+	ValidPostLoginRedirectUris  []string `json:"valid_post_login_redirect_uris"`
+	LogoutUri                   string   `json:"logout_uri"`
+	PostLogoutRedirectUri       string   `json:"post_logout_redirect_uri"`
+	ValidPostLogoutRedirectUris []string `json:"valid_post_logout_redirect_uris"`
+
+	SessionStorageType string `json:"session_storage_type"`
+
+	CookieNamePrefix     string                     `json:"cookie_name_prefix"`
+	SessionCookie        *SessionCookieConfig       `json:"session_cookie"`
+	AuthorizationHeader  *AuthorizationHeaderConfig `json:"authorization_header"`
+	AuthorizationCookie  *AuthorizationCookieConfig `json:"authorization_cookie"`
+	UnauthorizedBehavior string                     `json:"unauthorized_behavior"`
+
+	Authorization *AuthorizationConfig `json:"authorization"`
+
+	Headers []HeaderConfig `json:"headers"`
+
+	BypassAuthenticationRule string `json:"bypass_authentication_rule"`
+
+	ErrorPages *errorPages.ErrorPagesConfig `json:"error_pages"`
+
+	RequestedResources []string `json:"requested_resources"`
+}
+
+type ProviderConfig struct {
+	Url string `json:"url"`
+
+	InsecureSkipVerify     string `json:"insecure_skip_verify"`
+	InsecureSkipVerifyBool bool   `json:"insecure_skip_verify_bool"`
+
+	CABundle     string `json:"ca_bundle"`
+	CABundleFile string `json:"ca_bundle_file"`
+
+	ClientId              string `json:"client_id"`
+	ClientSecret          string `json:"client_secret"`
+	ClientJwtPrivateKey   string `json:"client_jwt_private_key"`
+	ClientJwtPrivateKeyId string `json:"client_jwt_private_key_id"`
+
+	UsePkce     string `json:"use_pkce"`
+	UsePkceBool bool   `json:"use_pkce_bool"`
+
+	ValidateAudience     string `json:"validate_audience"`
+	ValidateAudienceBool bool   `json:"validate_audience_bool"`
+	ValidAudience        string `json:"valid_audience"`
+
+	ValidateIssuer     string `json:"validate_issuer"`
+	ValidateIssuerBool bool   `json:"validate_issuer_bool"`
+	ValidIssuer        string `json:"valid_issuer"`
+
+	// AccessToken or IdToken or Introspection
+	TokenValidation string `json:"verification_token"`
+
+	TokenRenewalThreshold float64 `json:"token_renewal_threshold"`
+
+	UseClaimsFromUserInfo     string `json:"use_claims_from_user_info"`
+	UseClaimsFromUserInfoBool bool   `json:"use_claims_from_user_info_bool"`
+}
+
+type SessionCookieConfig struct {
+	Path     string `json:"path"`
+	Domain   string `json:"domain"`
+	Secure   bool   `json:"secure"`
+	HttpOnly bool   `json:"http_only"`
+	SameSite string `json:"same_site"`
+	MaxAge   int    `json:"max_age"`
+}
+
+type AuthorizationHeaderConfig struct {
+	Name string `json:"name"`
+}
+type AuthorizationCookieConfig struct {
+	Name string `json:"name"`
+}
+
+type AuthorizationConfig struct {
+	AssertClaims        []ClaimAssertion `json:"assert_claims"`
+	CheckOnEveryRequest bool             `json:"check_on_every_request"`
+}
+
+type ClaimAssertion struct {
+	Name  string   `json:"name"`
+	AnyOf []string `json:"anyOf"`
+	AllOf []string `json:"allOf"`
+}
+
+type HeaderConfig struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Values string `json:"values"`
+
+	// A reference to the parsed Value-template
+	Template *template.Template
+}

--- a/src/cookie.go
+++ b/src/cookie.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
 )
 
-func setChunkedCookies(config *Config, rw http.ResponseWriter, cookieName string, cookieValue string) {
+func setChunkedCookies(config *config.Config, rw http.ResponseWriter, cookieName string, cookieValue string) {
 	cookieChunks := utils.ChunkString(cookieValue, 3072)
 
 	baseCookie := createSessionCookie(config)
@@ -90,7 +91,7 @@ func getChunkedCookieNames(req *http.Request, cookieName string) (map[string]str
 	}
 	return cookieNames, nil
 }
-func clearChunkedCookie(config *Config, rw http.ResponseWriter, req *http.Request, cookieName string) error {
+func clearChunkedCookie(config *config.Config, rw http.ResponseWriter, req *http.Request, cookieName string) error {
 	chunkCount, err := getChunkedCookieCount(req, cookieName)
 	if err != nil {
 		return err
@@ -136,12 +137,12 @@ func makeCookieExpireImmediately(cookie *http.Cookie) *http.Cookie {
 	return cookie
 }
 
-func getCodeVerifierCookieName(config *Config) string {
+func getCodeVerifierCookieName(config *config.Config) string {
 	return makeCookieName(config, "CodeVerifier")
 }
-func getSessionCookieName(config *Config) string {
+func getSessionCookieName(config *config.Config) string {
 	return makeCookieName(config, "Session")
 }
-func makeCookieName(config *Config, name string) string {
+func makeCookieName(config *config.Config, name string) string {
 	return fmt.Sprintf("%s.%s", config.CookieNamePrefix, name)
 }

--- a/src/cookie_test.go
+++ b/src/cookie_test.go
@@ -5,12 +5,14 @@ import (
 	"math/rand"
 	"net/http"
 	"testing"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 )
 
 func TestSetChunkedCookiesNonChunked(t *testing.T) {
-	config := &Config{
+	config := &config.Config{
 		CookieNamePrefix: "TraefikOidcAuth",
-		SessionCookie: &SessionCookieConfig{
+		SessionCookie: &config.SessionCookieConfig{
 			Path:     "/",
 			Domain:   "",
 			Secure:   true,
@@ -32,9 +34,9 @@ func TestSetChunkedCookiesNonChunked(t *testing.T) {
 }
 
 func TestSetChunkedCookiesChunked(t *testing.T) {
-	config := &Config{
+	config := &config.Config{
 		CookieNamePrefix: "TraefikOidcAuth",
-		SessionCookie: &SessionCookieConfig{
+		SessionCookie: &config.SessionCookieConfig{
 			Path:     "/",
 			Domain:   "",
 			Secure:   true,

--- a/src/main.go
+++ b/src/main.go
@@ -16,6 +16,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/errorPages"
 	"github.com/sevensolutions/traefik-oidc-auth/src/rules"
 
@@ -32,7 +33,7 @@ type TraefikOidcAuth struct {
 	ProviderURL              *url.URL
 	ClientJwtPrivateKey      *rsa.PrivateKey
 	CallbackURL              *url.URL
-	Config                   *Config
+	Config                   *config.Config
 	SessionStorage           session.SessionStorage
 	DiscoveryDocument        *oidc.OidcDiscovery
 	Jwks                     *oidc.JwksHandler
@@ -257,18 +258,18 @@ func (toa *TraefikOidcAuth) attachHeaders(req *http.Request, session *session.Se
 
 		for _, header := range toa.Config.Headers {
 			if header.Value != "" {
-				if header.template == nil {
+				if header.Template == nil {
 					tpl, err := newTemplate().Parse(header.Value)
 
 					if err != nil {
 						return err
 					}
 
-					header.template = tpl
+					header.Template = tpl
 				}
 
 				var renderedValue bytes.Buffer
-				err := header.template.Execute(&renderedValue, evalContext)
+				err := header.Template.Execute(&renderedValue, evalContext)
 
 				if err == nil {
 					req.Header.Set(header.Name, renderedValue.String())
@@ -276,18 +277,18 @@ func (toa *TraefikOidcAuth) attachHeaders(req *http.Request, session *session.Se
 					req.Header.Set(header.Name, err.Error())
 				}
 			} else if header.Values != "" {
-				if header.template == nil {
+				if header.Template == nil {
 					tpl, err := newTemplate().Parse(header.Values)
 
 					if err != nil {
 						return err
 					}
 
-					header.template = tpl
+					header.Template = tpl
 				}
 
 				var renderedValue bytes.Buffer
-				err := header.template.Execute(&renderedValue, evalContext)
+				err := header.Template.Execute(&renderedValue, evalContext)
 
 				if err != nil {
 					req.Header.Set(header.Name, err.Error())

--- a/src/oidc_test.go
+++ b/src/oidc_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 	"github.com/sevensolutions/traefik-oidc-auth/src/oidc"
 )
@@ -19,8 +20,8 @@ import (
 func newGetUserInfoTest(t *testing.T, handler http.HandlerFunc) (*TraefikOidcAuth, *httptest.Server) {
 	server := httptest.NewServer(handler)
 
-	config := &Config{
-		Provider: &ProviderConfig{},
+	config := &config.Config{
+		Provider: &config.ProviderConfig{},
 		Scopes:   []string{"openid"},
 	}
 

--- a/src/session.go
+++ b/src/session.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
-	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
 )
 
 func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*session.SessionState, bool, map[string]interface{}, error) {
@@ -91,14 +90,8 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*session.Se
 	return session, updatedSession != nil, claims, nil
 }
 
-func validateSessionTicket(toa *TraefikOidcAuth, encryptedTicket string) (*session.SessionState, map[string]interface{}, *session.SessionState, error) {
-	plainSessionTicket, err := utils.Decrypt(encryptedTicket, toa.Config.Secret)
-	if err != nil {
-		toa.logger.Log(logging.LevelError, "Failed to decrypt session ticket: %v", err.Error())
-		return nil, nil, nil, err
-	}
-
-	session, err := toa.SessionStorage.TryGetSession(toa.logger, toa.Config, plainSessionTicket)
+func validateSessionTicket(toa *TraefikOidcAuth, sessionTicket string) (*session.SessionState, map[string]interface{}, *session.SessionState, error) {
+	session, err := toa.SessionStorage.TryGetSession(toa.logger, toa.Config, sessionTicket)
 	if err != nil {
 		toa.logger.Log(logging.LevelError, "Reading session failed: %v", err.Error())
 		return nil, nil, nil, err
@@ -241,14 +234,7 @@ func (toa *TraefikOidcAuth) storeSessionAndAttachCookie(session *session.Session
 
 	toa.logger.Log(logging.LevelDebug, "Session stored. Id %s", session.Id)
 
-	encryptedSessionTicket, err := utils.Encrypt(sessionTicket, toa.Config.Secret)
-	if err != nil {
-		toa.logger.Log(logging.LevelError, "Failed to encrypt session ticket: %s", err.Error())
-		http.Error(rw, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	setChunkedCookies(toa.Config, rw, getSessionCookieName(toa.Config), encryptedSessionTicket)
+	setChunkedCookies(toa.Config, rw, getSessionCookieName(toa.Config), sessionTicket)
 }
 
 func createSessionCookie(config *config.Config) *http.Cookie {

--- a/src/session.go
+++ b/src/session.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
@@ -97,7 +98,7 @@ func validateSessionTicket(toa *TraefikOidcAuth, encryptedTicket string) (*sessi
 		return nil, nil, nil, err
 	}
 
-	session, err := toa.SessionStorage.TryGetSession(plainSessionTicket)
+	session, err := toa.SessionStorage.TryGetSession(toa.logger, toa.Config, plainSessionTicket)
 	if err != nil {
 		toa.logger.Log(logging.LevelError, "Reading session failed: %v", err.Error())
 		return nil, nil, nil, err
@@ -231,7 +232,7 @@ func (toa *TraefikOidcAuth) validateToken(session *session.SessionState) (bool, 
 }
 
 func (toa *TraefikOidcAuth) storeSessionAndAttachCookie(session *session.SessionState, rw http.ResponseWriter) {
-	sessionTicket, err := toa.SessionStorage.StoreSession(session.Id, session)
+	sessionTicket, err := toa.SessionStorage.StoreSession(toa.logger, toa.Config, session.Id, session)
 	if err != nil {
 		toa.logger.Log(logging.LevelError, "Failed to store session: %s", err.Error())
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -250,7 +251,7 @@ func (toa *TraefikOidcAuth) storeSessionAndAttachCookie(session *session.Session
 	setChunkedCookies(toa.Config, rw, getSessionCookieName(toa.Config), encryptedSessionTicket)
 }
 
-func createSessionCookie(config *Config) *http.Cookie {
+func createSessionCookie(config *config.Config) *http.Cookie {
 	return &http.Cookie{
 		Name:     getSessionCookieName(config),
 		Value:    "",

--- a/src/session/cookieSessionStorage.go
+++ b/src/session/cookieSessionStorage.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
 )
 
 type CookieSessionStorage struct {
@@ -18,13 +19,25 @@ func CreateCookieSessionStorage() *CookieSessionStorage {
 func (storage *CookieSessionStorage) StoreSession(logger *logging.Logger, config *config.Config, sessionId string, state *SessionState) (string, error) {
 	stateJson, _ := json.Marshal(*state)
 
-	return string(stateJson), nil
+	encryptedSessionTicket, err := utils.Encrypt(string(stateJson), config.Secret)
+	if err != nil {
+		logger.Log(config.LogLevel, logging.LevelError, "Failed to encrypt session state: %s", err.Error())
+		return "", err
+	}
+
+	return encryptedSessionTicket, nil
 }
 
 func (storage *CookieSessionStorage) TryGetSession(logger *logging.Logger, config *config.Config, sessionTicket string) (*SessionState, error) {
+	plainSessionTicket, err := utils.Decrypt(sessionTicket, config.Secret)
+	if err != nil {
+		logger.Log(config.LogLevel, logging.LevelError, "Failed to decrypt session ticket: %v", err.Error())
+		return nil, err
+	}
+
 	state := &SessionState{}
 
-	err := json.Unmarshal([]byte(sessionTicket), state)
+	err = json.Unmarshal([]byte(plainSessionTicket), state)
 	if err != nil {
 		return nil, err
 	}

--- a/src/session/cookieSessionStorage.go
+++ b/src/session/cookieSessionStorage.go
@@ -1,6 +1,11 @@
 package session
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+)
 
 type CookieSessionStorage struct {
 }
@@ -10,13 +15,13 @@ func CreateCookieSessionStorage() *CookieSessionStorage {
 	return storage
 }
 
-func (storage *CookieSessionStorage) StoreSession(sessionId string, state *SessionState) (string, error) {
+func (storage *CookieSessionStorage) StoreSession(logger *logging.Logger, config *config.Config, sessionId string, state *SessionState) (string, error) {
 	stateJson, _ := json.Marshal(*state)
 
 	return string(stateJson), nil
 }
 
-func (storage *CookieSessionStorage) TryGetSession(sessionTicket string) (*SessionState, error) {
+func (storage *CookieSessionStorage) TryGetSession(logger *logging.Logger, config *config.Config, sessionTicket string) (*SessionState, error) {
 	state := &SessionState{}
 
 	err := json.Unmarshal([]byte(sessionTicket), state)

--- a/src/session/sessionStorage.go
+++ b/src/session/sessionStorage.go
@@ -4,11 +4,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 )
 
 type SessionStorage interface {
-	StoreSession(sessionId string, state *SessionState) (string, error)
-	TryGetSession(sessionTicket string) (*SessionState, error)
+	StoreSession(logger *logging.Logger, config *config.Config, sessionId string, state *SessionState) (string, error)
+	TryGetSession(logger *logging.Logger, config *config.Config, sessionTicket string) (*SessionState, error)
 }
 
 type SessionState struct {

--- a/src/session_test.go
+++ b/src/session_test.go
@@ -4,16 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
 func TestSessionIdpTokenExpiration(t *testing.T) {
-	config := &Config{
-		Provider: &ProviderConfig{
+	config := &config.Config{
+		Provider: &config.ProviderConfig{
 			TokenRenewalThreshold: 0.5,
 		},
-		SessionCookie: &SessionCookieConfig{
+		SessionCookie: &config.SessionCookieConfig{
 			MaxAge: 0,
 		},
 	}


### PR DESCRIPTION
This PR refactors the session storage to make it ready for supporting multiple session storage backends.

It also moves the encryption to the cookie storage because not all backends need encryption.
Eg. a redis backend would simply return a "ticket id" which doesn't need to be encrypted because it doesn't contain data.