### PR TITLE
fix: remove extra config.LogLevel arg from logger.Log calls in cookieSessionStorage

### DIFF
--- a/src/session/cookieSessionStorage.go
+++ b/src/session/cookieSessionStorage.go
@@ -21,7 +21,7 @@ func (storage *CookieSessionStorage) StoreSession(logger *logging.Logger, config
 
 	encryptedSessionTicket, err := utils.Encrypt(string(stateJson), config.Secret)
 	if err != nil {
-		logger.Log(config.LogLevel, logging.LevelError, "Failed to encrypt session state: %s", err.Error())
+		logger.Log(logging.LevelError, "Failed to encrypt session state: %s", err.Error())
 		return "", err
 	}
 
@@ -31,7 +31,7 @@ func (storage *CookieSessionStorage) StoreSession(logger *logging.Logger, config
 func (storage *CookieSessionStorage) TryGetSession(logger *logging.Logger, config *config.Config, sessionTicket string) (*SessionState, error) {
 	plainSessionTicket, err := utils.Decrypt(sessionTicket, config.Secret)
 	if err != nil {
-		logger.Log(config.LogLevel, logging.LevelError, "Failed to decrypt session ticket: %v", err.Error())
+		logger.Log(logging.LevelError, "Failed to decrypt session ticket: %v", err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

Fix malformed log output caused by an extra argument in two `logger.Log()` calls in `cookieSessionStorage.go`.

The `Logger.Log()` signature is:

```go
func (logger *Logger) Log(level string, format string, a ...interface{})
```

But both call sites in `cookieSessionStorage.go` passed `config.LogLevel` as the first argument, which shifted `logging.LevelError` into the format-string position and pushed the actual message into the variadic args:

```go
// Before (broken):
logger.Log(config.LogLevel, logging.LevelError, "Failed to decrypt session ticket: %v", err.Error())
// level=config.LogLevel, format="ERROR", a=["Failed to decrypt...", err]
// Output: ERROR%!(EXTRA string=Failed to decrypt session ticket: %v, string=cipher: message authentication failed)

// After (fixed):
logger.Log(logging.LevelError, "Failed to decrypt session ticket: %v", err.Error())
// level="ERROR", format="Failed to decrypt session ticket: %v", a=[err]
// Output: Failed to decrypt session ticket: cipher: message authentication failed
```

This matches the pattern used by all other `logger.Log()` call sites in the codebase.

Fixes #273
