### PR TITLE
Website, documentation improvement: Updated Pocket ID repository URL

### DIFF
--- a/website/docs/identity-providers/pocket-id.md
+++ b/website/docs/identity-providers/pocket-id.md
@@ -2,7 +2,7 @@
 # Pocket ID
 A simple and easy-to-use OIDC provider that allows users to authenticate exclusively using [passkeys](https://fidoalliance.org/passkeys/).
 
-https://github.com/stonith404/pocket-id
+[https://github.com/pocket-id/pocket-id](https://github.com/pocket-id/pocket-id)
 
 ## Setup Pocket ID
 


### PR DESCRIPTION
There was a reference to the old pocket-id repository, this is the new url.