### PR TITLE
feat: add AuthorizationParams to pass extra query params to the IDP 

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	ErrorPages *errorPages.ErrorPagesConfig `json:"error_pages"`
 
 	RequestedResources []string `json:"requested_resources"`
+
+	// Additional query parameters to send to the IDP's authorization endpoint, eg. acr_values or prompt.
+	// A `prompt` query parameter on the incoming /login request still takes precedence over this.
+	AuthorizationParams map[string]string `json:"authorization_params"`
 }
 
 type ProviderConfig struct {

--- a/src/main.go
+++ b/src/main.go
@@ -680,6 +680,10 @@ func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http
 			toa.logger.Log(logging.LevelWarn, "AuthorizationParams contains reserved key '%s' which will be ignored", key)
 			continue
 		}
+
+		if override := req.URL.Query().Get(key); override != "" {
+			value = override
+		}
 		urlValues.Set(key, value)
 	}
 
@@ -747,6 +751,15 @@ func (toa *TraefikOidcAuth) doubleRedirectToProvider(rw http.ResponseWriter, req
 
 	urlValues := url.Values{
 		"state": {stateBase64},
+	}
+
+	for key := range toa.Config.AuthorizationParams {
+		if reservedAuthorizationParams[key] {
+			continue
+		}
+		if override := req.URL.Query().Get(key); override != "" {
+			urlValues.Add(key, override)
+		}
 	}
 
 	if prompt := req.URL.Query().Get("prompt"); prompt != "" {

--- a/src/main.go
+++ b/src/main.go
@@ -630,6 +630,16 @@ func (toa *TraefikOidcAuth) needsDoubleRedirect(req *http.Request) bool {
 	return false
 }
 
+// Protocol-critical parameters that AuthorizationParams must not be allowed to override.
+var reservedAuthorizationParams = map[string]bool{
+	"response_type": true,
+	"client_id":     true,
+	"redirect_uri":  true,
+	"state":         true,
+	"scope":         true,
+	"resource":      true,
+}
+
 func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http.Request, redirectUrl string) {
 	toa.logger.Log(logging.LevelInfo, "Redirecting to OIDC provider...")
 
@@ -665,8 +675,16 @@ func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http
 		"resource":      toa.Config.RequestedResources,
 	}
 
+	for key, value := range toa.Config.AuthorizationParams {
+		if reservedAuthorizationParams[key] {
+			toa.logger.Log(logging.LevelWarn, "AuthorizationParams contains reserved key '%s' which will be ignored", key)
+			continue
+		}
+		urlValues.Set(key, value)
+	}
+
 	if prompt := req.URL.Query().Get("prompt"); prompt != "" {
-		urlValues.Add("prompt", prompt)
+		urlValues.Set("prompt", prompt)
 	}
 
 	if toa.Config.Provider.UsePkceBool {

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -47,6 +47,7 @@ But: If you're using YAML-files for configuration you can use [traefik's templat
 | `BypassAuthenticationRule`* | no | `string` | *none* | Specifies an optional rule to bypass authentication. See [Bypass Authentication Rule](./bypass-authentication-rule.md) for more details. |
 | `ErrorPages` | no | [`ErrorPages`](#error-pages) | *none* | Allows you to customize some error pages. See *ErrorPages* block. |
 | `RequestedResources` | no | `string[]`| *none* | An array of resource URIs according to [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) for which the token should be requested. | 
+| `AuthorizationParams` | no | `map[string]string`| *none* | Additional query parameters to send to the IDP's authorization endpoint, eg. `acr_values` to request a specific authentication context (step-up authentication) or a default `prompt`. Reserved protocol parameters (`response_type`, `client_id`, `redirect_uri`, `state`, `scope`, `resource`) cannot be overridden this way and are ignored with a warning. A `prompt` query parameter on the incoming `/login` request still takes precedence over the configured value. |
 
 
 ## Provider Block {#provider}

--- a/workspaces/configs/http.yml
+++ b/workspaces/configs/http.yml
@@ -34,6 +34,9 @@ http:
             Name: "CustomAuth"
           #BypassAuthenticationRule: "Header(`cache-control`, `no-cache`) || HeaderRegexp(`X-Real-Ip`, `^172\\.18\\.`)"
           #UnauthorizedBehavior: "Unauthorized"
+          #AuthorizationParams:
+          #  acr_values: "aal2"
+          #  prompt: "login"
           # Authorization:
           #   AssertClaims:
           #     - Name: roles


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                        
  - Adds a new `AuthorizationParams` config option (`map[string]string`) that lets you attach extra query parameters to the authorization request sent to the IDP — e.g. `acr_values` for step-up authentication, or a default `prompt`.                                                                            
  - Protocol-critical parameters (`response_type`, `client_id`, `redirect_uri`, `state`, `scope`, `resource`) cannot be overridden this way; if configured, they're ignored with a warning log.                                                                                                                     
  - An explicit `prompt` query parameter on the incoming `/login` request still takes precedence over the configured default. 