### PR TITLE
feat: support loading secret values from a file via ${file:/path} 

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -24,6 +24,8 @@ type AcceptType struct {
 }
 
 // Expands the environment variable if it is enclosed in ${}. If the variable is not present, the original value is returned.
+// Also supports reading the value from a file via ${file:/path/to/file}, eg. to consume a Docker/Kubernetes
+// secret mounted as a file, since environment variables can be read by anyone with access to `docker inspect`.
 func ExpandEnvironmentVariableString(value string) string {
 	after, hasPrefix := strings.CutPrefix(value, "${")
 
@@ -31,10 +33,18 @@ func ExpandEnvironmentVariableString(value string) string {
 		variableName, hasSuffix := strings.CutSuffix(after, "}")
 
 		if hasSuffix {
-			variableValue, isDefined := os.LookupEnv(variableName)
+			if filePath, isFile := strings.CutPrefix(variableName, "file:"); isFile {
+				fileContent, err := os.ReadFile(filePath)
 
-			if isDefined {
-				return variableValue
+				if err == nil {
+					return strings.TrimSpace(string(fileContent))
+				}
+			} else {
+				variableValue, isDefined := os.LookupEnv(variableName)
+
+				if isDefined {
+					return variableValue
+				}
 			}
 		}
 	}

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -2,8 +2,44 @@ package utils
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+func TestExpandEnvironmentVariableStringFromEnv(t *testing.T) {
+	t.Setenv("TEST_EXPAND_ENV_VAR", "value-from-env")
+
+	result := ExpandEnvironmentVariableString("${TEST_EXPAND_ENV_VAR}")
+
+	if result != "value-from-env" {
+		t.Fatalf("expected value-from-env, got %s", result)
+	}
+}
+
+func TestExpandEnvironmentVariableStringFromFile(t *testing.T) {
+	secretFile := filepath.Join(t.TempDir(), "secret")
+
+	if err := os.WriteFile(secretFile, []byte("value-from-file\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := ExpandEnvironmentVariableString("${file:" + secretFile + "}")
+
+	if result != "value-from-file" {
+		t.Fatalf("expected value-from-file, got %s", result)
+	}
+}
+
+func TestExpandEnvironmentVariableStringFromMissingFile(t *testing.T) {
+	value := "${file:/no/such/file}"
+
+	result := ExpandEnvironmentVariableString(value)
+
+	if result != value {
+		t.Fatalf("expected the original value to be returned unchanged, got %s", result)
+	}
+}
 
 func TestChunkString(t *testing.T) {
 	originalText := "abcdefghijklmnopqrstuvwxyz"

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -22,6 +22,16 @@ If a variable is not defined, the provided value is used as-is.
 Please note that you can only use a single environment variable using this syntax and it **does not allow templating**.
 So something like this wouldn't work: `https://auth.${MY_DOMAIN}/auth/${CLIENT_ID}`.  
 But: If you're using YAML-files for configuration you can use [traefik's templating](https://doc.traefik.io/traefik/providers/file/#go-templating).
+
+Alternatively, you can read the value from a file using `${file:/path/to/file}`. This is useful for secrets
+(eg. `ClientSecret` or `Secret`) when using Docker/Kubernetes secrets mounted as files, since environment
+variables set on a container can be read by anyone with access to `docker inspect`, while a mounted secret
+file cannot. The file content is trimmed of surrounding whitespace/newlines. Eg.:
+```yml
+Secret: "${file:/run/secrets/oidc_secret}"
+Provider:
+  ClientSecret: "${file:/run/secrets/oidc_client_secret}"
+```
 :::
 
 | Name | Required | Type | Default | Description |


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                                                                                        
  - Extends the existing `${VAR}` environment-variable expansion syntax with a `${file:/path/to/file}` form, so any `*`-marked config value (e.g. `Secret`, `Provider.ClientSecret`, `Provider.ClientJwtPrivateKey`) can be sourced from a file instead of an environment variable.                                 
  - Motivation: environment variables set on a container are readable by anyone with access to `docker inspect`, whereas a mounted secret file (Docker/Kubernetes secrets) is not — this lets sensitive values stay off the container's env entirely.                                                               
  - File content is trimmed of surrounding whitespace/newlines. If the file can't be read, the value falls back to the literal string unchanged, matching the existing behavior for an undefined `${VAR}`.  