### PR TITLE
feat: encrypt the callback state

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -337,7 +337,7 @@ func (toa *TraefikOidcAuth) handleCallback(rw http.ResponseWriter, req *http.Req
 		return
 	}
 
-	state, err := oidc.DecodeState(base64State)
+	state, err := oidc.DecodeState(base64State, toa.Config.Secret)
 	if err != nil {
 		toa.logger.Log(logging.LevelWarn, "State on callback request is invalid.")
 		http.Error(rw, "State is invalid", http.StatusInternalServerError)
@@ -507,7 +507,7 @@ func (toa *TraefikOidcAuth) handleLogout(rw http.ResponseWriter, req *http.Reque
 		RedirectUrl: redirectUri,
 	}
 
-	base64State, err := oidc.EncodeState(state)
+	base64State, err := oidc.EncodeState(state, toa.Config.Secret)
 	if err != nil {
 		toa.logger.Log(logging.LevelError, "Failed to serialize state: %s", err.Error())
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -694,7 +694,7 @@ func (toa *TraefikOidcAuth) redirectToProvider(rw http.ResponseWriter, req *http
 		IsChallenge: isChallenge,
 	}
 
-	stateBase64, err := oidc.EncodeState(&state)
+	stateBase64, err := oidc.EncodeState(&state, toa.Config.Secret)
 	if err != nil {
 		toa.logger.Log(logging.LevelError, "Failed to serialize state: %s", err.Error())
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -787,7 +787,7 @@ func (toa *TraefikOidcAuth) doubleRedirectToProvider(rw http.ResponseWriter, req
 		IsChallenge: isChallenge,
 	}
 
-	stateBase64, err := oidc.EncodeState(&state)
+	stateBase64, err := oidc.EncodeState(&state, toa.Config.Secret)
 	if err != nil {
 		toa.logger.Log(logging.LevelError, "Failed to serialize state: %s", err.Error())
 		http.Error(rw, err.Error(), http.StatusInternalServerError)

--- a/src/oidc/state.go
+++ b/src/oidc/state.go
@@ -3,6 +3,8 @@ package oidc
 import (
 	"encoding/base64"
 	"encoding/json"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
 )
 
 type OidcState struct {
@@ -16,28 +18,42 @@ type OidcState struct {
 	IsChallenge bool `json:"is_challenge"`
 }
 
-func EncodeState(state *OidcState) (string, error) {
+// EncodeState serializes and encrypts the state so it can be safely round-tripped through the
+// identity provider as an opaque value. It must be encrypted rather than just encoded: the callback
+// endpoint trusts the decoded fields (notably RedirectUrl) without further validation, so a plain
+// encoding would let anyone forge a state value and turn the callback into an open redirect.
+func EncodeState(state *OidcState, secret string) (string, error) {
 	stateBytes, err := json.Marshal(state)
 
 	if err != nil {
 		return "", err
 	}
 
-	stateBase64 := base64.RawURLEncoding.EncodeToString(stateBytes)
-	return stateBase64, nil
+	encrypted, err := utils.Encrypt(string(stateBytes), secret)
+	if err != nil {
+		return "", err
+	}
+
+	// Encrypt() returns standard base64, which includes '+', '/' and '='. Re-encode with URL-safe
+	// base64 so the token travels through query strings and identity provider redirects unmodified,
+	// matching the character set of the previous plain encoding.
+	return base64.RawURLEncoding.EncodeToString([]byte(encrypted)), nil
 }
 
-func DecodeState(base64State string) (*OidcState, error) {
-	stateBytes, err := base64.RawURLEncoding.DecodeString(base64State)
+func DecodeState(encodedState string, secret string) (*OidcState, error) {
+	encryptedBytes, err := base64.RawURLEncoding.DecodeString(encodedState)
+	if err != nil {
+		return nil, err
+	}
 
+	stateBytes, err := utils.Decrypt(string(encryptedBytes), secret)
 	if err != nil {
 		return nil, err
 	}
 
 	var state OidcState
-	err2 := json.Unmarshal(stateBytes, &state)
-	if err2 != nil {
-		return nil, err2
+	if err := json.Unmarshal([]byte(stateBytes), &state); err != nil {
+		return nil, err
 	}
 
 	return &state, nil

--- a/src/oidc/state_test.go
+++ b/src/oidc/state_test.go
@@ -1,0 +1,107 @@
+package oidc
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+const testStateSecret = "MLFs4TT99kOOq8h3UAVRtYoCTDYXiRcZ"
+
+func TestEncodeDecodeStateRoundtrip(t *testing.T) {
+	original := &OidcState{
+		Action:      "Login",
+		RedirectUrl: "https://example.com/dashboard",
+		IsChallenge: true,
+	}
+
+	encoded, err := EncodeState(original, testStateSecret)
+	if err != nil {
+		t.Fatalf("EncodeState failed: %v", err)
+	}
+
+	decoded, err := DecodeState(encoded, testStateSecret)
+	if err != nil {
+		t.Fatalf("DecodeState failed: %v", err)
+	}
+
+	if decoded.Action != original.Action {
+		t.Errorf("expected Action %q, got %q", original.Action, decoded.Action)
+	}
+	if decoded.RedirectUrl != original.RedirectUrl {
+		t.Errorf("expected RedirectUrl %q, got %q", original.RedirectUrl, decoded.RedirectUrl)
+	}
+	if decoded.IsChallenge != original.IsChallenge {
+		t.Errorf("expected IsChallenge %v, got %v", original.IsChallenge, decoded.IsChallenge)
+	}
+}
+
+func TestEncodeStateIsNotPlainBase64Json(t *testing.T) {
+	state := &OidcState{
+		Action:      "Logout",
+		RedirectUrl: "https://google.com/",
+	}
+
+	encoded, err := EncodeState(state, testStateSecret)
+	if err != nil {
+		t.Fatalf("EncodeState failed: %v", err)
+	}
+
+	// A forged state used to be plain base64url(json) with no integrity protection, which let an
+	// attacker hand-craft e.g. {"action":"Logout","redirect_url":"https://google.com/"} and hit
+	// /oidc/callback directly to trigger an open redirect. Guard against regressing back to that by
+	// asserting the encoded value can't be interpreted as raw base64-encoded JSON.
+	if decodedBytes, err := base64.RawURLEncoding.DecodeString(encoded); err == nil {
+		if strings.Contains(string(decodedBytes), "redirect_url") {
+			t.Fatalf("state is stored as plain, forgeable base64-encoded JSON: %s", decodedBytes)
+		}
+	}
+}
+
+func TestDecodeStateRejectsForgedState(t *testing.T) {
+	// Simulate an attacker who doesn't know the secret hand-crafting a state value directly (as
+	// opposed to tampering with a genuine one), the way the old base64(json) encoding allowed.
+	forged := &OidcState{
+		Action:      "Logout",
+		RedirectUrl: "https://evil.example/phish",
+	}
+	forgedBytes, err := EncodeState(forged, "a-completely-different-secret-32")
+	if err != nil {
+		t.Fatalf("failed to build forged state fixture: %v", err)
+	}
+
+	if _, err := DecodeState(forgedBytes, testStateSecret); err == nil {
+		t.Fatal("expected DecodeState to reject a state encoded with a different secret, but it did not")
+	}
+}
+
+func TestDecodeStateRejectsTamperedState(t *testing.T) {
+	original := &OidcState{
+		Action:      "Login",
+		RedirectUrl: "https://example.com/ok",
+	}
+
+	encoded, err := EncodeState(original, testStateSecret)
+	if err != nil {
+		t.Fatalf("EncodeState failed: %v", err)
+	}
+
+	// Flip a character in the ciphertext to simulate tampering with a genuine state value.
+	tampered := []rune(encoded)
+	mid := len(tampered) / 2
+	if tampered[mid] == 'A' {
+		tampered[mid] = 'B'
+	} else {
+		tampered[mid] = 'A'
+	}
+
+	if _, err := DecodeState(string(tampered), testStateSecret); err == nil {
+		t.Fatal("expected DecodeState to reject a tampered state value, but it did not")
+	}
+}
+
+func TestDecodeStateRejectsGarbage(t *testing.T) {
+	if _, err := DecodeState("not-a-valid-state", testStateSecret); err == nil {
+		t.Fatal("expected DecodeState to reject a garbage state value, but it did not")
+	}
+}


### PR DESCRIPTION
This PR encrypts the callback state to protect it against modification and exposure and because it should be treated as an opaque value.