### PR TITLE
fix: bound the session cookie chunk count on read, write and clear

### DIFF
--- a/src/cookie.go
+++ b/src/cookie.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	cookieChunkSize = 3072
-	maxCookieChunks = 32
+	maxCookieChunks = 16
 )
 
 func setChunkedCookies(config *config.Config, rw http.ResponseWriter, cookieName string, cookieValue string) error {

--- a/src/cookie.go
+++ b/src/cookie.go
@@ -12,8 +12,17 @@ import (
 	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
 )
 
-func setChunkedCookies(config *config.Config, rw http.ResponseWriter, cookieName string, cookieValue string) {
-	cookieChunks := utils.ChunkString(cookieValue, 3072)
+const (
+	cookieChunkSize = 3072
+	maxCookieChunks = 32
+)
+
+func setChunkedCookies(config *config.Config, rw http.ResponseWriter, cookieName string, cookieValue string) error {
+	cookieChunks := utils.ChunkString(cookieValue, cookieChunkSize)
+
+	if len(cookieChunks) > maxCookieChunks {
+		return fmt.Errorf("the session needs %d cookie chunks but only %d are supported", len(cookieChunks), maxCookieChunks)
+	}
 
 	baseCookie := createSessionCookie(config)
 	baseCookie.Name = cookieName
@@ -35,6 +44,8 @@ func setChunkedCookies(config *config.Config, rw http.ResponseWriter, cookieName
 			http.SetCookie(rw, c)
 		}
 	}
+
+	return nil
 }
 func readChunkedCookie(req *http.Request, cookieName string) (string, error) {
 	chunkCount, err := getChunkedCookieCount(req, cookieName)
@@ -75,49 +86,39 @@ func getChunkedCookieCount(req *http.Request, cookieName string) (int, error) {
 		return 0, err
 	}
 
-	return chunkCount, nil
-}
-func getChunkedCookieNames(req *http.Request, cookieName string) (map[string]struct{}, error) {
-	cookieNames := make(map[string]struct{})
-	chunkCount, err := getChunkedCookieCount(req, cookieName)
-	if err != nil {
-		return nil, err
-	}
-	if chunkCount == 0 {
-		cookieNames[cookieName] = struct{}{}
-	} else {
-		cookieNames[cookieName+".Chunks"] = struct{}{}
-		for i := 0; i < chunkCount; i++ {
-			cookieNames[fmt.Sprintf("%s.%d", cookieName, i+1)] = struct{}{}
-		}
-	}
-	return cookieNames, nil
-}
-func clearChunkedCookie(config *config.Config, rw http.ResponseWriter, req *http.Request, cookieName string) error {
-	chunkCount, err := getChunkedCookieCount(req, cookieName)
-	if err != nil {
-		return err
+	if chunkCount < 0 || chunkCount > maxCookieChunks {
+		return 0, fmt.Errorf("cookie %s.Chunks contains an out of range chunk count of %d", cookieName, chunkCount)
 	}
 
+	return chunkCount, nil
+}
+func clearChunkedCookie(config *config.Config, rw http.ResponseWriter, req *http.Request, cookieName string) {
 	baseCookie := createSessionCookie(config)
-	baseCookie.Name = cookieName
 	baseCookie.Value = ""
 	makeCookieExpireImmediately(baseCookie)
 
-	if chunkCount == 0 {
-		http.SetCookie(rw, baseCookie)
-	} else {
-		c := baseCookie
-		c.Name = cookieName + ".Chunks"
-		http.SetCookie(rw, c)
+	for _, name := range presentChunkedCookieNames(req, cookieName) {
+		c := *baseCookie
+		c.Name = name
+		http.SetCookie(rw, &c)
+	}
+}
 
-		for i := 0; i < chunkCount; i++ {
-			c.Name = fmt.Sprintf("%s.%d", cookieName, i+1)
-			http.SetCookie(rw, c)
+func presentChunkedCookieNames(req *http.Request, cookieName string) []string {
+	names := []string{cookieName}
+	prefix := cookieName + "."
+
+	for _, c := range req.Cookies() {
+		if len(names) >= maxCookieChunks+2 {
+			break
+		}
+
+		if strings.HasPrefix(c.Name, prefix) {
+			names = append(names, c.Name)
 		}
 	}
 
-	return nil
+	return names
 }
 
 func parseCookieSameSite(sameSite string) http.SameSite {

--- a/src/cookie_test.go
+++ b/src/cookie_test.go
@@ -191,6 +191,133 @@ func TestReadChunkedCookieWithNoCount(t *testing.T) {
 	}
 }
 
+func TestReadChunkedCookieWithOutOfRangeCount(t *testing.T) {
+	for _, chunkCount := range []string{"-1", "1000000000"} {
+		req, err := http.NewRequest("GET", "https://example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.AddCookie(&http.Cookie{
+			Name:  "TraefikOidcAuth.Session.Chunks",
+			Value: chunkCount,
+		})
+
+		cookieValue, err := readChunkedCookie(req, "TraefikOidcAuth.Session")
+
+		if err == nil || cookieValue != "" {
+			t.Errorf("expected a chunk count of %s to be rejected, got value %q and error %v", chunkCount, cookieValue, err)
+		}
+	}
+}
+
+func TestClearChunkedCookieClearsEveryPresentChunk(t *testing.T) {
+	cfg := &config.Config{
+		CookieNamePrefix: "TraefikOidcAuth",
+		SessionCookie:    &config.SessionCookieConfig{Path: "/"},
+	}
+
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.Chunks", Value: "1000000000"})
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.1", Value: "111"})
+
+	rw := newMockResponseWriter()
+
+	clearChunkedCookie(cfg, rw, req, "TraefikOidcAuth.Session")
+
+	headers := rw.HeaderMap.Values("Set-Cookie")
+
+	if len(headers) != 3 {
+		t.Fatalf("expected the 3 cookies present on the request to be cleared, got %d: %v", len(headers), headers)
+	}
+
+	for _, name := range []string{"TraefikOidcAuth.Session=", "TraefikOidcAuth.Session.Chunks=", "TraefikOidcAuth.Session.1="} {
+		found := false
+		for _, raw := range headers {
+			if strings.HasPrefix(raw, name) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected %s to be cleared, got %v", name, headers)
+		}
+	}
+}
+
+func TestClearChunkedCookieIsBounded(t *testing.T) {
+	cfg := &config.Config{
+		CookieNamePrefix: "TraefikOidcAuth",
+		SessionCookie:    &config.SessionCookieConfig{Path: "/"},
+	}
+
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 5000; i++ {
+		req.AddCookie(&http.Cookie{Name: fmt.Sprintf("TraefikOidcAuth.Session.%d", i+1), Value: "x"})
+	}
+
+	rw := newMockResponseWriter()
+
+	clearChunkedCookie(cfg, rw, req, "TraefikOidcAuth.Session")
+
+	headers := rw.HeaderMap.Values("Set-Cookie")
+
+	if len(headers) > maxCookieChunks+2 {
+		t.Errorf("expected at most %d cleared cookies, got %d", maxCookieChunks+2, len(headers))
+	}
+}
+
+func TestSetChunkedCookiesRejectsAnOversizedValue(t *testing.T) {
+	cfg := &config.Config{
+		CookieNamePrefix: "TraefikOidcAuth",
+		SessionCookie:    &config.SessionCookieConfig{Path: "/"},
+	}
+
+	rw := newMockResponseWriter()
+
+	tooLong := randomFixedLengthString(cookieChunkSize*maxCookieChunks + 1)
+
+	if err := setChunkedCookies(cfg, rw, "TraefikOidcAuth.Session", tooLong); err == nil {
+		t.Fatal("expected a value that needs more chunks than can be read back to be rejected")
+	}
+
+	if len(rw.HeaderMap.Values("Set-Cookie")) != 0 {
+		t.Error("expected no cookie to be written for an oversized value")
+	}
+
+	stillFits := randomFixedLengthString(cookieChunkSize * maxCookieChunks)
+
+	if err := setChunkedCookies(cfg, rw, "TraefikOidcAuth.Session", stillFits); err != nil {
+		t.Errorf("expected the largest readable value to be accepted, got %v", err)
+	}
+
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, raw := range rw.HeaderMap.Values("Set-Cookie") {
+		name, value, _ := strings.Cut(strings.Split(raw, ";")[0], "=")
+		req.AddCookie(&http.Cookie{Name: name, Value: value})
+	}
+
+	readBack, err := readChunkedCookie(req, "TraefikOidcAuth.Session")
+	if err != nil {
+		t.Fatalf("expected the largest accepted value to be readable again, got %v", err)
+	}
+
+	if readBack != stillFits {
+		t.Error("expected the value read back to match the value written")
+	}
+}
+
 type mockResponseWriter struct {
 	HeaderMap http.Header
 }

--- a/src/session.go
+++ b/src/session.go
@@ -234,7 +234,12 @@ func (toa *TraefikOidcAuth) storeSessionAndAttachCookie(session *session.Session
 
 	toa.logger.Log(logging.LevelDebug, "Session stored. Id %s", session.Id)
 
-	setChunkedCookies(toa.Config, rw, getSessionCookieName(toa.Config), sessionTicket)
+	err = setChunkedCookies(toa.Config, rw, getSessionCookieName(toa.Config), sessionTicket)
+	if err != nil {
+		toa.logger.Log(logging.LevelError, "Failed to store the session in a cookie: %s", err.Error())
+		http.Error(rw, "Failed to store the session", http.StatusInternalServerError)
+		return
+	}
 }
 
 func createSessionCookie(config *config.Config) *http.Cookie {


### PR DESCRIPTION
Split out of #290, which is now a draft. This one is self-contained and doesn't depend on the other five.

## The problem

`TraefikOidcAuth.Session.Chunks` is a client cookie and its value was used directly as a loop bound. A request carrying

```
Cookie: TraefikOidcAuth.Session.Chunks=2000000000
```

made `clearChunkedCookie` write that many `Set-Cookie` headers, and **every request without a valid session reaches that code** (`ServeHTTP` clears the session cookie before handing over to `handleUnauthenticated`).

## What changed

- The chunk count is range checked when it's read. Anything negative or above `maxCookieChunks` (32) is rejected.
- Clearing no longer trusts the count at all: it expires the chunk cookies that are actually on the request, so a client that already has a broken cookie can recover. That walk is bounded too, since the cookies on the request are just as attacker controlled — a megabyte of chunk-shaped cookies produced tens of thousands of `Set-Cookie` headers otherwise.
- The writer had no limit of its own, so a session ticket above the maximum would have been written at login and then rejected on every request after it: a login loop where it used to work. `setChunkedCookies` now returns an error and `storeSessionAndAttachCookie` reports it instead of writing a session that can't be read back.
- `clearChunkedCookie` loses its error return. It can't fail anymore now that it doesn't read the count, and no caller ever looked at it.

32 chunks × 3072 bytes is ~98 KB of session ticket, well past what any browser accepts, so the limit isn't reachable in a working setup.

## Test plan

- New tests in `src/cookie_test.go` cover the out-of-range count, the bounded clear, that every cookie present on the request is expired, and the oversized write.
- The same code passed `go test -race ./...`, `go vet ./...`, `gofmt -l .` and `task test:e2e` (19/19 against Keycloak, so through Yaegi and not just the Go compiler) as part of #290. CI runs the unit tests on this branch.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. The write-side bound and the bounded clear came out of an adversarial review pass over the first version of the fix. I can explain and defend every line here.
