### PR TITLE
fix: handle providers without an end_session_endpoint on logout

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -465,13 +465,6 @@ func (toa *TraefikOidcAuth) handleLogout(rw http.ResponseWriter, req *http.Reque
 
 	// https://openid.net/specs/openid-connect-rpinitiated-1_0.html
 
-	endSessionURL, err := url.Parse(toa.DiscoveryDocument.EndSessionEndpoint)
-	if err != nil {
-		toa.logger.Log(logging.LevelError, "Error while parsing the AuthorizationEndpoint: %s", err.Error())
-		http.Error(rw, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	callbackUri := toa.GetAbsoluteCallbackURL(req).String()
 	redirectUri := utils.EnsureAbsoluteUrl(req, toa.Config.PostLogoutRedirectUri)
 
@@ -481,16 +474,31 @@ func (toa *TraefikOidcAuth) handleLogout(rw http.ResponseWriter, req *http.Reque
 	}
 
 	if redirectUriFromQuery != "" {
-		redirectUriFromQuery, err = utils.ValidateRedirectUri(redirectUriFromQuery, toa.Config.ValidPostLogoutRedirectUris, toa.RedirectUriWildcardsEnabled)
+		validatedRedirectUri, err := utils.ValidateRedirectUri(redirectUriFromQuery, toa.Config.ValidPostLogoutRedirectUris, toa.RedirectUriWildcardsEnabled)
 		if err != nil {
 			toa.logger.Log(logging.LevelError, "%s", err.Error())
 			http.Error(rw, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		if redirectUriFromQuery != "" {
-			redirectUri = utils.EnsureAbsoluteUrl(req, redirectUriFromQuery)
+		if validatedRedirectUri != "" {
+			redirectUri = utils.EnsureAbsoluteUrl(req, validatedRedirectUri)
 		}
+	}
+
+	clearChunkedCookie(toa.Config, rw, req, getSessionCookieName(toa.Config))
+
+	if toa.DiscoveryDocument.EndSessionEndpoint == "" {
+		toa.logger.Log(logging.LevelWarn, "The provider doesn't provide an end_session_endpoint, so the session at the provider can't be ended. The local session has been cleared.")
+		http.Redirect(rw, req, redirectUri, http.StatusFound)
+		return
+	}
+
+	endSessionURL, err := url.Parse(toa.DiscoveryDocument.EndSessionEndpoint)
+	if err != nil {
+		toa.logger.Log(logging.LevelError, "Error while parsing the EndSessionEndpoint: %s", err.Error())
+		http.Error(rw, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	state := &oidc.OidcState{

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -6,9 +6,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+	"github.com/sevensolutions/traefik-oidc-auth/src/oidc"
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
@@ -94,5 +98,121 @@ func TestAttachHeaders_UsesThePreparsedTemplates(t *testing.T) {
 
 	if _, ok := req.Header["X-Empty"]; !ok {
 		t.Error("expected a header without a value to still be set")
+	}
+}
+
+func newLogoutTest(endSessionEndpoint string) *TraefikOidcAuth {
+	callbackURL, _ := url.Parse("/oidc/callback")
+
+	return &TraefikOidcAuth{
+		logger:      logging.CreateLogger(logging.LevelError),
+		CallbackURL: callbackURL,
+		Config: &config.Config{
+			Secret:                "0123456789abcdef0123456789abcdef",
+			Provider:              &config.ProviderConfig{ClientId: "my-client"},
+			CookieNamePrefix:      "TraefikOidcAuth",
+			SessionCookie:         &config.SessionCookieConfig{Path: "/"},
+			PostLogoutRedirectUri: "/",
+		},
+		DiscoveryDocument: &oidc.OidcDiscovery{EndSessionEndpoint: endSessionEndpoint},
+	}
+}
+
+func TestHandleLogout_WithoutEndSessionEndpoint(t *testing.T) {
+	toa := newLogoutTest("")
+
+	req := httptest.NewRequest("GET", "https://app.example.com/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.Chunks", Value: "2"})
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.1", Value: "some"})
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.2", Value: "ticket"})
+	rw := httptest.NewRecorder()
+
+	toa.handleLogout(rw, req, &session.SessionState{IdToken: "some-id-token"})
+
+	location := rw.Header().Get("Location")
+
+	if location != "https://app.example.com/" {
+		t.Errorf("expected a redirect to the post logout redirect uri, got %q", location)
+	}
+
+	assertSessionCookiesCleared(t, rw)
+}
+
+func TestHandleLogout_WithEndSessionEndpoint(t *testing.T) {
+	toa := newLogoutTest("https://idp.example.com/end-session")
+
+	req := httptest.NewRequest("GET", "https://app.example.com/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.Chunks", Value: "2"})
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.1", Value: "some"})
+	req.AddCookie(&http.Cookie{Name: "TraefikOidcAuth.Session.2", Value: "ticket"})
+	rw := httptest.NewRecorder()
+
+	toa.handleLogout(rw, req, &session.SessionState{IdToken: "some-id-token"})
+
+	location, err := url.Parse(rw.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if location.Host != "idp.example.com" || location.Path != "/end-session" {
+		t.Errorf("expected a redirect to the end session endpoint, got %q", location)
+	}
+
+	if got := location.Query().Get("id_token_hint"); got != "some-id-token" {
+		t.Errorf("expected the id token to be sent as a hint, got %q", got)
+	}
+
+	assertSessionCookiesCleared(t, rw)
+}
+
+func TestHandleLogout_RejectsAnUnlistedRedirectUri(t *testing.T) {
+	toa := newLogoutTest("https://idp.example.com/end-session")
+
+	req := httptest.NewRequest("GET", "https://app.example.com/logout?redirect_uri=https://evil.example.com/", nil)
+	rw := httptest.NewRecorder()
+
+	toa.handleLogout(rw, req, &session.SessionState{IdToken: "some-id-token"})
+
+	if rw.Code != http.StatusBadRequest {
+		t.Errorf("expected an unlisted redirect uri to be rejected, got status %d", rw.Code)
+	}
+
+	if location := rw.Header().Get("Location"); location != "" {
+		t.Errorf("expected no redirect, got %q", location)
+	}
+}
+
+func TestHandleLogout_AcceptsAListedRedirectUri(t *testing.T) {
+	toa := newLogoutTest("")
+	toa.Config.ValidPostLogoutRedirectUris = []string{"/bye"}
+
+	req := httptest.NewRequest("GET", "https://app.example.com/logout?post_logout_redirect_uri=/bye", nil)
+	rw := httptest.NewRecorder()
+
+	toa.handleLogout(rw, req, &session.SessionState{IdToken: "some-id-token"})
+
+	if got := rw.Header().Get("Location"); got != "https://app.example.com/bye" {
+		t.Errorf("expected a redirect to the listed uri, got %q", got)
+	}
+}
+
+func assertSessionCookiesCleared(t *testing.T, rw *httptest.ResponseRecorder) {
+	t.Helper()
+
+	cleared := make(map[string]bool)
+
+	for _, raw := range rw.Header().Values("Set-Cookie") {
+		name, _, _ := strings.Cut(strings.Split(raw, ";")[0], "=")
+
+		lower := strings.ToLower(raw)
+		if strings.Contains(lower, "max-age=0") || strings.Contains(lower, "max-age=-1") {
+			cleared[name] = true
+		}
+	}
+
+	for _, name := range []string{"TraefikOidcAuth.Session.Chunks", "TraefikOidcAuth.Session.1", "TraefikOidcAuth.Session.2"} {
+		if !cleared[name] {
+			t.Errorf("expected %s to be cleared, got %v", name, rw.Header().Values("Set-Cookie"))
+		}
 	}
 }

--- a/website/docs/getting-started/how-it-works.md
+++ b/website/docs/getting-started/how-it-works.md
@@ -79,14 +79,24 @@ sequenceDiagram
     participant OAuth as OAuth Provider
 
     User->>Traefik: Navigate to /logout
+    Traefik->>Traefik: Clear Session and Cookie
     Traefik-->>User: Redirect to OAuth Provider for logout
     User->>OAuth: Follow redirect (end_session_endpoint)
     OAuth->>OAuth: Clear SSO session
     OAuth->>User: Redirect to Plugin Callback (/oidc/callback)
     User->>Traefik: Follow Plugin Callback (/oidc/callback)
-    Traefik->>Traefik: Clear Session and Cookie
     Traefik->>User: Redirect to `PostLogoutRedirectUri`
 ```
+
+The local session is cleared before the user is sent to the provider, so an
+interrupted logout still ends the session on your side.
+
+:::note
+If your provider doesn't publish an `end_session_endpoint` in its discovery document,
+the plugin can't ask it to end the SSO session. In that case it clears the local session
+and redirects to `PostLogoutRedirectUri` right away, and logs a warning. You'll still be
+logged in at the provider, so the next login may complete without a prompt.
+:::
 
 :::tip
 The configured `PostLogoutRedirectUri` is the default url to which the user will be redirected after the logout is completed.


### PR DESCRIPTION
Split out of #290, which is now a draft. This one is self-contained and doesn't depend on the other five.

## The problem

`handleLogout` parses `DiscoveryDocument.EndSessionEndpoint` unconditionally. When the provider doesn't publish one, `url.Parse("")` succeeds and gives an empty url, so the redirect the user follows becomes

```
?client_id=...&post_logout_redirect_uri=...&id_token_hint=eyJhbGciOi...
```

relative to the current path, i.e. back to `/logout`. That loops, and it puts the id token in the address bar, in the browser history and in the access logs of anything in front of traefik.

## What changed

- The endpoint is checked before it's parsed. Without one, the local session is cleared and the user goes straight to `PostLogoutRedirectUri`, with a warning that the SSO session at the provider is still open, so the next login may complete without a prompt.
- The session cookie is cleared **before** the user leaves for the provider, rather than when they come back through the callback. An abandoned logout — the user closes the tab at the IDP's confirmation screen — now still ends the local session.
- The sequence diagram in `how-it-works.md` is updated to match, and gains a note about providers without an `end_session_endpoint`.

Moving the parse below the `redirect_uri` validation means that branch no longer has an outer `err` to assign to, so the validated uri gets its own variable instead of overwriting the one it was validated from. No behaviour change there.

## Test plan

- New `src/main_test.go` covers both logout paths (with and without an `end_session_endpoint`), that the session cookie is expired on both, that an unlisted `redirect_uri` is rejected with 400, and that a listed one is accepted.
- The same code passed `go test -race ./...`, `go vet ./...`, `gofmt -l .` and `task test:e2e` (19/19 against Keycloak) as part of #290. CI runs the unit tests on this branch.
- Not covered by a real round trip: Keycloak publishes an `end_session_endpoint`, so the fallback branch is only exercised by unit tests. If you have a provider without one handy, that's the case worth poking at.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. I can explain and defend every line here.
