### PR TITLE
fix: harden the requests to the provider and the JWKS cache

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Test with the Go CLI
         working-directory: ./src
-        run: go test
+        run: go test -race ./...

--- a/src/config.go
+++ b/src/config.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 
@@ -277,6 +278,7 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 
 	httpClient := &http.Client{
 		Transport: httpTransport,
+		Timeout:   30 * time.Second,
 	}
 
 	logger.Log(logging.LevelInfo, "Configuration loaded successfully, starting OIDC Auth middleware...")

--- a/src/oidc.go
+++ b/src/oidc.go
@@ -261,11 +261,21 @@ func (toa *TraefikOidcAuth) renewToken(refreshToken string) (*oidc.OidcTokenResp
 		"client_id":     {toa.Config.Provider.ClientId},
 		"scope":         {strings.Join(toa.Config.Scopes, " ")},
 		"refresh_token": {refreshToken},
-		"resources":     toa.Config.RequestedResources,
+		"resource":      toa.Config.RequestedResources,
 	}
 
 	if toa.Config.Provider.ClientSecret != "" {
 		urlValues.Add("client_secret", toa.Config.Provider.ClientSecret)
+	}
+
+	if toa.ClientJwtPrivateKey != nil {
+		clientAssertionToken, err := toa.getClientAssertionJwtToken()
+		if err != nil {
+			return nil, err
+		}
+
+		urlValues.Add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+		urlValues.Add("client_assertion", clientAssertionToken)
 	}
 
 	resp, err := toa.httpClient.PostForm(toa.DiscoveryDocument.TokenEndpoint, urlValues)

--- a/src/oidc.go
+++ b/src/oidc.go
@@ -231,6 +231,12 @@ func (toa *TraefikOidcAuth) introspectToken(token string) (bool, map[string]inte
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		toa.logger.Log(logging.LevelError, "introspectToken: received bad HTTP response from Provider (Status: %d): %s", resp.StatusCode, string(body))
+		return false, nil, errors.New("invalid status code")
+	}
+
 	var introspectResponse map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&introspectResponse)
 

--- a/src/oidc/jwks.go
+++ b/src/oidc/jwks.go
@@ -149,6 +149,9 @@ func (h *JwksHandler) Keyfunc(token *jwt.Token) (any, error) {
 }
 
 func (h *JwksHandler) getRsaKey(kid string) (*rsa.PublicKey, error) {
+	h.Lock.RLock()
+	defer h.Lock.RUnlock()
+
 	k := h.findRsaKey(kid)
 
 	if k != nil {
@@ -158,6 +161,9 @@ func (h *JwksHandler) getRsaKey(kid string) (*rsa.PublicKey, error) {
 	return nil, errors.New("unknown kid " + kid)
 }
 func (h *JwksHandler) getEcdsaKey(kid string) (*ecdsa.PublicKey, error) {
+	h.Lock.RLock()
+	defer h.Lock.RUnlock()
+
 	k := h.findEcdsaKey(kid)
 
 	if k != nil {

--- a/src/oidc/jwks_test.go
+++ b/src/oidc/jwks_test.go
@@ -1,9 +1,15 @@
 package oidc
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
 )
 
 func TestKeyfunc_MissingOrInvalidKid(t *testing.T) {
@@ -49,4 +55,63 @@ func TestKeyfunc_MissingOrInvalidKid(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeyfunc_ConcurrentWithReload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(rw).Encode(JwksKeys{
+			Keys: []JwksKey{
+				{
+					Kid: "test-key",
+					Kty: "RSA",
+					Use: "sig",
+					N:   "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+					E:   "AQAB",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	h := &JwksHandler{Url: server.URL}
+	logger := logging.CreateLogger(logging.LevelError)
+
+	if err := h.EnsureLoaded(logger, server.Client(), false); err != nil {
+		t.Fatal(err)
+	}
+
+	token := &jwt.Token{
+		Method: jwt.SigningMethodRS256,
+		Header: map[string]any{"kid": "test-key"},
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				h.Keyfunc(token)
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 100; j++ {
+			h.Lock.Lock()
+			h.CacheDate = time.Time{}
+			h.Lock.Unlock()
+
+			if err := h.EnsureLoaded(logger, server.Client(), false); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
 }

--- a/src/oidc_test.go
+++ b/src/oidc_test.go
@@ -9,6 +9,8 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -472,5 +474,61 @@ func TestIntrospectToken_BadStatusCode(t *testing.T) {
 
 	if active || err == nil {
 		t.Errorf("expected a failed introspection request to be an error, got active=%v err=%v", active, err)
+	}
+}
+
+func TestRenewToken_SendsResourceAndClientAssertion(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var form url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if err := req.ParseForm(); err != nil {
+			t.Error(err)
+			return
+		}
+
+		mu.Lock()
+		form = req.PostForm
+		mu.Unlock()
+
+		rw.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(rw).Encode(oidc.OidcTokenResponse{AccessToken: "new-access-token"})
+	}))
+	defer server.Close()
+
+	toa := &TraefikOidcAuth{
+		logger:     logging.CreateLogger(logging.LevelError),
+		httpClient: server.Client(),
+		Config: &config.Config{
+			Provider:           &config.ProviderConfig{ClientId: "my-client", ClientJwtPrivateKeyId: "my-key-id"},
+			Scopes:             []string{"openid"},
+			RequestedResources: []string{"https://api.example.com"},
+		},
+		ClientJwtPrivateKey: privateKey,
+		DiscoveryDocument:   &oidc.OidcDiscovery{TokenEndpoint: server.URL},
+	}
+
+	if _, err := toa.renewToken("some-refresh-token"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if got := form.Get("resource"); got != "https://api.example.com" {
+		t.Errorf("expected the requested resource to be sent as resource, got %q", got)
+	}
+
+	if form.Get("client_assertion") == "" {
+		t.Error("expected a client assertion to be sent")
+	}
+
+	if got := form.Get("client_assertion_type"); got != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+		t.Errorf("unexpected client_assertion_type %q", got)
 	}
 }

--- a/src/oidc_test.go
+++ b/src/oidc_test.go
@@ -454,3 +454,23 @@ func setupJWKS(t *testing.T, toa *TraefikOidcAuth, privateKey *rsa.PrivateKey) *
 	toa.Jwks.Url = jwksServer.URL
 	return jwksServer
 }
+
+func TestIntrospectToken_BadStatusCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		http.Error(rw, `{"active":true}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	toa := &TraefikOidcAuth{
+		logger:            logging.CreateLogger(logging.LevelError),
+		httpClient:        server.Client(),
+		Config:            &config.Config{Provider: &config.ProviderConfig{}},
+		DiscoveryDocument: &oidc.OidcDiscovery{IntrospectionEndpoint: server.URL},
+	}
+
+	active, _, err := toa.introspectToken("some-token")
+
+	if active || err == nil {
+		t.Errorf("expected a failed introspection request to be an error, got active=%v err=%v", active, err)
+	}
+}

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -44,7 +44,7 @@ tasks:
     desc: 'Run all go unit tests'
     dir: 'src'
     cmds:
-      - go test
+      - go test -race ./...
   test:e2e:
     desc: 'Run all end to end tests'
     dir: 'e2e'


### PR DESCRIPTION
Split out of #290, which is now a draft. Four independent fixes to how the plugin talks to the provider, plus the CI change that makes the first one's test meaningful. Each is its own commit, reviewable on its own.

## `fix: take the read lock when looking up a JWKS key`

`JwksHandler` carries an `RWMutex`, but only the reload path ever took it. `getRsaKey`/`getEcdsaKey` walked `RsaKeys`/`EcdsaKeys` unlocked, so validating a token while the JWKS cache was being replaced was a data race. Reproducible with `go test -race` via the added test.

## `ci: run the tests of every package with the race detector`

`go test` in `./src` only builds that one package, so the tests under `src/oidc`, `src/rules` and `src/utils` have never been executed — by CI or by `task test:unit`. Now `go test -race ./...`, which is also what makes the JWKS test above show the problem it guards against.

This is in the same PR as the JWKS fix on purpose: without it the new test compiles but proves nothing.

## `fix: give the requests to the provider a timeout`

`httpClient` had no `Timeout`, so a provider that accepts a connection and then never answers holds a traefik goroutine indefinitely — discovery, token exchange, refresh, introspection and userinfo all go through it. 30s.

## `fix: check the status code of the introspection response`

`introspectToken` decoded the response body whatever the status code was, so an error payload from the provider was read as an introspection result. A body that happens to carry `"active": true` would then decide the outcome.

## `fix: keep the refresh request in sync with the auth code exchange`

`renewToken` had drifted apart from `exchangeAuthCode` in two ways:

- it sent `resources`, while RFC 8707 (and the auth code exchange) use `resource`, so `RequestedResources` were dropped on every refresh and the renewed token could come back with the wrong audience
- it never sent the client assertion, so a provider configured with `ClientJwtPrivateKey` rejected every refresh

### Upgrade note

Refresh requests now carry `resource` when `RequestedResources` is set. A provider that allows it on the auth code grant but not on the refresh grant would start rejecting refreshes.

## Test plan

- New tests: JWKS lookup under `-race`, introspection with a non-200, and the refresh request's form values.
- The same code passed `go test -race ./...`, `go vet ./...`, `gofmt -l .`, `govulncheck ./...` and `task test:e2e` (19/19 against Keycloak, so through Yaegi and not just the Go compiler) as part of #290. CI runs the unit tests on this branch.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. The CI gap was found by an adversarial review pass over the diff — the JWKS test was passing for the wrong reason. I can explain and defend every line here.
