### PR TITLE
fix: survive a transient token renewal failure, add an opt-in ClockSkewTolerance

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -34,6 +34,7 @@ func CreateConfig() *config.Config {
 			ValidateAudienceBool:      true,
 			TokenValidation:           "IdToken",
 			TokenRenewalThreshold:     0.75,
+			ClockSkewTolerance:        0,
 			UseClaimsFromUserInfoBool: false,
 		},
 		// Note: It looks like we're not allowed to specify a default value for arrays here.
@@ -186,6 +187,11 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 	if cfg.Provider.TokenRenewalThreshold < 0.5 || cfg.Provider.TokenRenewalThreshold > 1.0 {
 		logger.Log(logging.LevelError, "Invalid TokenRenewalThreshold. The value must be >= 0.5 and <= 1.0.")
 		return nil, errors.New("invalid TokenRenewalThreshold")
+	}
+
+	if cfg.Provider.ClockSkewTolerance < 0 || cfg.Provider.ClockSkewTolerance > 300 {
+		logger.Log(logging.LevelError, "Invalid ClockSkewTolerance. The value must be >= 0 and <= 300 seconds.")
+		return nil, errors.New("invalid ClockSkewTolerance")
 	}
 
 	var conditionalAuth *rules.RequestCondition

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -91,6 +91,8 @@ type ProviderConfig struct {
 
 	TokenRenewalThreshold float64 `json:"token_renewal_threshold"`
 
+	ClockSkewTolerance int `json:"clock_skew_tolerance"`
+
 	UseClaimsFromUserInfo     string `json:"use_claims_from_user_info"`
 	UseClaimsFromUserInfoBool bool   `json:"use_claims_from_user_info_bool"`
 }

--- a/src/oidc.go
+++ b/src/oidc.go
@@ -254,6 +254,8 @@ func (toa *TraefikOidcAuth) introspectToken(token string) (bool, map[string]inte
 	}
 }
 
+var errRefreshTokenRejected = errors.New("the provider rejected the refresh token")
+
 func (toa *TraefikOidcAuth) renewToken(refreshToken string) (*oidc.OidcTokenResponse, error) {
 	urlValues := url.Values{
 		"grant_type":    {"refresh_token"},
@@ -277,7 +279,12 @@ func (toa *TraefikOidcAuth) renewToken(refreshToken string) (*oidc.OidcTokenResp
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		toa.logger.Log(logging.LevelError, "renewToken: received bad HTTP response from Provider: %s", string(body))
+		toa.logger.Log(logging.LevelError, "renewToken: received bad HTTP response from Provider (Status: %d): %s", resp.StatusCode, string(body))
+
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return nil, errRefreshTokenRejected
+		}
+
 		return nil, errors.New("invalid status code")
 	}
 

--- a/src/oidc.go
+++ b/src/oidc.go
@@ -127,6 +127,10 @@ func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode str
 	return tokenResponse, nil
 }
 
+func (toa *TraefikOidcAuth) clockSkewTolerance() time.Duration {
+	return time.Duration(toa.Config.Provider.ClockSkewTolerance) * time.Second
+}
+
 func (toa *TraefikOidcAuth) validateTokenLocally(tokenString string) (bool, map[string]interface{}, error) {
 	claims := jwt.MapClaims{}
 
@@ -137,6 +141,7 @@ func (toa *TraefikOidcAuth) validateTokenLocally(tokenString string) (bool, map[
 
 	options := []jwt.ParserOption{
 		jwt.WithExpirationRequired(),
+		jwt.WithLeeway(toa.clockSkewTolerance()),
 	}
 
 	if toa.Config.Provider.ValidateIssuerBool {
@@ -350,7 +355,9 @@ func (toa *TraefikOidcAuth) getUserInfo(accessToken string, idTokenSubject strin
 			return nil, err
 		}
 
-		options := []jwt.ParserOption{}
+		options := []jwt.ParserOption{
+			jwt.WithLeeway(toa.clockSkewTolerance()),
+		}
 
 		if toa.Config.Provider.ValidateIssuerBool {
 			options = append(options, jwt.WithIssuer(toa.Config.Provider.ValidIssuer))

--- a/src/oidc_test.go
+++ b/src/oidc_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
@@ -453,4 +454,94 @@ func setupJWKS(t *testing.T, toa *TraefikOidcAuth, privateKey *rsa.PrivateKey) *
 
 	toa.Jwks.Url = jwksServer.URL
 	return jwksServer
+}
+
+func newClockSkewTest(t *testing.T, clockSkewTolerance int) (*TraefikOidcAuth, *rsa.PrivateKey) {
+	t.Helper()
+
+	privateKey, err := generateRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	toa := &TraefikOidcAuth{
+		logger: logging.CreateLogger(logging.LevelError),
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{ClockSkewTolerance: clockSkewTolerance},
+		},
+		httpClient: http.DefaultClient,
+		Jwks:       &oidc.JwksHandler{},
+	}
+
+	jwksServer := setupJWKS(t, toa, privateKey)
+	t.Cleanup(jwksServer.Close)
+
+	return toa, privateKey
+}
+
+func signTestToken(t *testing.T, privateKey *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-kid"
+
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return signedToken
+}
+
+func TestValidateTokenLocally_ToleratesClockSkew(t *testing.T) {
+	toa, privateKey := newClockSkewTest(t, 30)
+
+	now := time.Now()
+
+	notYetValid := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"nbf": now.Add(10 * time.Second).Unix(),
+		"iat": now.Add(10 * time.Second).Unix(),
+		"exp": now.Add(1 * time.Hour).Unix(),
+	})
+
+	ok, _, err := toa.validateTokenLocally(notYetValid)
+	if !ok || err != nil {
+		t.Errorf("expected a token from a slightly fast clock to be accepted, got %v", err)
+	}
+
+	justExpired := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"exp": now.Add(-10 * time.Second).Unix(),
+	})
+
+	ok, _, err = toa.validateTokenLocally(justExpired)
+	if !ok || err != nil {
+		t.Errorf("expected a token from a slightly slow clock to be accepted, got %v", err)
+	}
+}
+
+func TestValidateTokenLocally_RejectsBeyondClockSkew(t *testing.T) {
+	toa, privateKey := newClockSkewTest(t, 30)
+
+	now := time.Now()
+
+	notYetValid := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"nbf": now.Add(5 * time.Minute).Unix(),
+		"exp": now.Add(1 * time.Hour).Unix(),
+	})
+
+	if ok, _, _ := toa.validateTokenLocally(notYetValid); ok {
+		t.Error("expected a token that is not valid yet to be rejected")
+	}
+
+	expired := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"exp": now.Add(-5 * time.Minute).Unix(),
+	})
+
+	if ok, _, _ := toa.validateTokenLocally(expired); ok {
+		t.Error("expected an expired token to be rejected")
+	}
 }

--- a/src/session.go
+++ b/src/session.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
+const renewalRetryInterval = 30 * time.Second
+
 func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*session.SessionState, bool, map[string]interface{}, error) {
 	// Use AuthorizationHeader, if present
 	if toa.Config.AuthorizationHeader != nil && toa.Config.AuthorizationHeader.Name != "" {
@@ -110,15 +112,28 @@ func validateSessionTicket(toa *TraefikOidcAuth, sessionTicket string) (*session
 	}
 
 	if !success || err != nil || idpTokenExpiresSoon {
+		renewalIsOptional := success && err == nil
+
+		if renewalIsOptional && renewalFailedRecently(session) {
+			return session, claims, nil, nil
+		}
+
 		if session.RefreshToken != "" {
 			toa.logger.Log(logging.LevelInfo, "Trying to renew tokens...")
 
-			newTokens, err := toa.renewToken(session.RefreshToken)
+			newTokens, renewErr := toa.renewToken(session.RefreshToken)
 
-			if err != nil {
-				return nil, nil, nil, err
+			if renewErr != nil {
+				if renewalIsOptional && renewErr != errRefreshTokenRejected {
+					toa.logger.Log(logging.LevelWarn, "Failed to renew the tokens before they expire, continuing with the current session: %s", renewErr.Error())
+					session.RenewalFailedAt = time.Now()
+					return session, claims, session, nil
+				}
+
+				return nil, nil, nil, renewErr
 			}
 
+			session.RenewalFailedAt = time.Time{}
 			session.AccessToken = newTokens.AccessToken
 
 			if newTokens.RefreshToken != "" {
@@ -162,6 +177,14 @@ func validateSessionTicket(toa *TraefikOidcAuth, sessionTicket string) (*session
 	}
 
 	return session, claims, nil, nil
+}
+
+func renewalFailedRecently(session *session.SessionState) bool {
+	if session.RenewalFailedAt.IsZero() {
+		return false
+	}
+
+	return time.Since(session.RenewalFailedAt) < renewalRetryInterval
 }
 
 func checkIdpTokenExpiresSoon(toa *TraefikOidcAuth, session *session.SessionState) bool {

--- a/src/session/sessionStorage.go
+++ b/src/session/sessionStorage.go
@@ -22,6 +22,8 @@ type SessionState struct {
 	IsAuthorized   bool      `json:"is_authorized"`
 	TokenExpiresIn int       `json:"token_expires_in"`
 
+	RenewalFailedAt time.Time `json:"renewal_failed_at"`
+
 	// Set when this session was (re-)established via a redirect triggered by UnauthorizedBehavior's
 	// Challenge, regardless of whether the resulting session ends up authorized - the callback may be
 	// handled by a different, more permissive middleware instance than the one that failed the check.

--- a/src/session_test.go
+++ b/src/session_test.go
@@ -1,11 +1,16 @@
 package src
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+	"github.com/sevensolutions/traefik-oidc-auth/src/oidc"
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
@@ -48,5 +53,160 @@ func TestSessionIdpTokenExpiration(t *testing.T) {
 
 	if !expiresSoon {
 		t.Fail()
+	}
+}
+
+type fixedSessionStorage struct {
+	state *session.SessionState
+}
+
+func (s *fixedSessionStorage) StoreSession(logger *logging.Logger, cfg *config.Config, sessionId string, state *session.SessionState) (string, error) {
+	return "ticket", nil
+}
+
+func (s *fixedSessionStorage) TryGetSession(logger *logging.Logger, cfg *config.Config, sessionTicket string) (*session.SessionState, error) {
+	return s.state, nil
+}
+
+func newRenewalTest(t *testing.T, tokenIsActive bool) *TraefikOidcAuth {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/introspect", func(rw http.ResponseWriter, req *http.Request) {
+		json.NewEncoder(rw).Encode(map[string]interface{}{"active": tokenIsActive, "sub": "user-1"})
+	})
+	mux.HandleFunc("/token", func(rw http.ResponseWriter, req *http.Request) {
+		http.Error(rw, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	state := &session.SessionState{
+		Id:             "session-1",
+		AccessToken:    "current-access-token",
+		RefreshToken:   "current-refresh-token",
+		RefreshedAt:    time.Now().Add(-50 * time.Second),
+		TokenExpiresIn: 60,
+	}
+
+	toa := &TraefikOidcAuth{
+		logger:     logging.CreateLogger(logging.LevelError),
+		httpClient: server.Client(),
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{
+				TokenValidation:       "Introspection",
+				TokenRenewalThreshold: 0.75,
+			},
+		},
+		SessionStorage: &fixedSessionStorage{state: state},
+		DiscoveryDocument: &oidc.OidcDiscovery{
+			IntrospectionEndpoint: server.URL + "/introspect",
+			TokenEndpoint:         server.URL + "/token",
+		},
+	}
+
+	return toa
+}
+
+func newLocalValidationRenewalTest(t *testing.T, renewalStatusCode int) (*TraefikOidcAuth, *session.SessionState, *int) {
+	t.Helper()
+
+	privateKey, err := generateRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renewalAttempts := 0
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		renewalAttempts++
+		http.Error(rw, `{"error":"invalid_grant"}`, renewalStatusCode)
+	}))
+	t.Cleanup(tokenServer.Close)
+
+	state := &session.SessionState{
+		Id:             "session-1",
+		AccessToken:    signTestToken(t, privateKey, jwt.MapClaims{"sub": "user-1", "exp": time.Now().Add(10 * time.Minute).Unix()}),
+		RefreshToken:   "current-refresh-token",
+		RefreshedAt:    time.Now().Add(-50 * time.Second),
+		TokenExpiresIn: 60,
+	}
+
+	toa := &TraefikOidcAuth{
+		logger:     logging.CreateLogger(logging.LevelError),
+		httpClient: http.DefaultClient,
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{
+				TokenValidation:       "AccessToken",
+				TokenRenewalThreshold: 0.75,
+			},
+		},
+		SessionStorage:    &fixedSessionStorage{state: state},
+		Jwks:              &oidc.JwksHandler{},
+		DiscoveryDocument: &oidc.OidcDiscovery{TokenEndpoint: tokenServer.URL},
+	}
+
+	jwksServer := setupJWKS(t, toa, privateKey)
+	t.Cleanup(jwksServer.Close)
+
+	return toa, state, &renewalAttempts
+}
+
+func TestValidateSessionTicket_KeepsSessionWhenRenewalFailsTemporarily(t *testing.T) {
+	toa, _, renewalAttempts := newLocalValidationRenewalTest(t, http.StatusInternalServerError)
+
+	sessionState, _, updatedSession, err := validateSessionTicket(toa, "ticket")
+
+	if err != nil {
+		t.Fatalf("expected a temporary renewal failure to keep the session, got %v", err)
+	}
+
+	if sessionState == nil {
+		t.Fatal("expected the current session to be kept")
+	}
+
+	if updatedSession == nil || updatedSession.RenewalFailedAt.IsZero() {
+		t.Error("expected the failed renewal to be recorded on the session")
+	}
+
+	if *renewalAttempts != 1 {
+		t.Errorf("expected one renewal attempt, got %d", *renewalAttempts)
+	}
+
+	if _, _, _, err := validateSessionTicket(toa, "ticket"); err != nil {
+		t.Fatalf("expected the session to still be usable, got %v", err)
+	}
+
+	if *renewalAttempts != 1 {
+		t.Errorf("expected the renewal not to be retried on the next request, got %d attempts", *renewalAttempts)
+	}
+}
+
+func TestValidateSessionTicket_DropsSessionWhenRefreshTokenIsRejected(t *testing.T) {
+	toa, _, _ := newLocalValidationRenewalTest(t, http.StatusBadRequest)
+
+	sessionState, _, _, err := validateSessionTicket(toa, "ticket")
+
+	if err == nil {
+		t.Fatal("expected a rejected refresh token to end the session")
+	}
+
+	if sessionState != nil {
+		t.Errorf("expected no session, got %v", sessionState)
+	}
+}
+
+func TestValidateSessionTicket_FailsWhenRenewalFailsForAnExpiredToken(t *testing.T) {
+	toa := newRenewalTest(t, false)
+
+	sessionState, _, _, err := validateSessionTicket(toa, "ticket")
+
+	if err == nil {
+		t.Fatal("expected an error when the token is no longer valid and cannot be renewed")
+	}
+
+	if sessionState != nil {
+		t.Errorf("expected no session, got %v", sessionState)
 	}
 }

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -106,6 +106,7 @@ A path-only entry (without a scheme/host) only matches a path-only *redirect_uri
 | `TokenValidation`* | no | `string` | `IdToken` | Specifies which token or method should be used to validate the authentication cookie. Can be either `AccessToken`, `IdToken` or `Introspection`. `Introspection` may not work when using PKCE. |
 | `UseClaimsFromUserInfo`* | no | `bool` | `false` | When enabled, an additional request to the provider's `userinfo_endpoint` is made to validate the token and to retrieve additional claims. The userinfo claims are merged directly into the token claims, with userinfo values overriding token values for non-security-critical claims. |
 | `TokenRenewalThreshold` | no | `float` | `0.75` | The percentage of the token's lifetime after which it should be renewed before expiration. The value must be between 0.5 and 1.0. |
+| `ClockSkewTolerance` | no | `int` | `0` | How much clock difference between traefik and your provider is tolerated, in seconds, when the `exp` and `nbf` claims of a token are validated. The value must be between 0 and 300. Set this if you see *token is not valid yet* or *token is expired* errors even though both clocks look roughly correct. Note that it also delays the expiration of tokens by the same amount, so keep it just large enough to cover the drift you actually have. |
 
 :::warning
 When using `UseClaimsFromUserInfo`, an additional request to the provider's `userinfo_endpoint` is made to validate the token and to retrieve additional claims.


### PR DESCRIPTION
Split out of #290, which is now a draft. Two commits, both about the lifetime of a token.

Related: #257, #236. Neither should be auto-closed — #236 needs the reporter to confirm the new option helps.

## `feat: add an opt-in ClockSkewTolerance for token validation`

A provider whose clock runs slightly ahead of traefik issues tokens with an `nbf` in the near future, which the parser rejects with *token is not valid yet* until the difference passes. That's #236.

`Provider.ClockSkewTolerance` (seconds, 0-300) is passed to the jwt parser as a leeway for `exp` and `nbf`, both when validating a token locally and when the `userinfo_endpoint` answers with a JWT.

**It defaults to `0`, so nothing changes unless you set it.** I went back and forth on this: most OIDC libraries default to 30-60s, and at `0` this only helps people who read the docs. But shipping a relaxed default would loosen token validation for everyone who upgrades without asking for it, and the tolerance also delays expiration by the same amount. Happy to flip it to `30` if you'd rather — it's a one-line change and the docs row already explains the trade-off.

## `fix: only drop the session when the provider rejects the refresh token`

Tokens are renewed once they reach `TokenRenewalThreshold` (0.75 by default) of their lifetime, so the current one is normally still valid at that point. A failing refresh dropped the session anyway and bounced the user to the IDP, which is what #257 describes: the page breaks, and a reload logs you straight back in.

If the current token still validates, a failed renewal is now logged and the request continues with it.

Keeping the session on *any* failed renewal would be too generous though. `renewToken` returned the same opaque error for a 502 and for a 400 `invalid_grant`, so a refresh token the provider deliberately rejected — revoked, logged out at the IDP, account disabled — would keep the old tokens working until they expire, up to 25% of their lifetime. A 4xx from the token endpoint (except 429) is now a definitive rejection and ends the session as before, so revocation still takes effect promptly.

The failed attempt is recorded on the session (`RenewalFailedAt`, 30s) so a struggling IDP doesn't get one POST per request for the rest of the token's lifetime.

## Test plan

- New tests: a temporary failure (500) keeps the session, records the attempt and doesn't retry on the next request; a 400 ends it; an expired token that can't be renewed still fails. Plus clock skew accepted within tolerance and rejected beyond it.
- The same code passed `go test -race ./...`, `go vet ./...`, `gofmt -l .` and `task test:e2e` (19/19 against Keycloak, so through Yaegi and not just the Go compiler) as part of #290. CI runs the unit tests on this branch.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. The revoked-refresh-token hole in the first version of the renewal fix came out of an adversarial security review pass. I can explain and defend every line here.
