### PR TITLE
fix: validate TokenValidation and the header templates when the config is loaded

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -243,11 +243,29 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 
 	}
 
-	for _, header := range cfg.Headers {
+	for i := range cfg.Headers {
+		header := &cfg.Headers[i]
+
 		if header.Value != "" && header.Values != "" {
 			logger.Log(logging.LevelError, "Invalid Header: you can only use one of Value or Values, not both")
 			return nil, errors.New("invalid Header")
 		}
+
+		templateSource := header.Value
+		if templateSource == "" {
+			templateSource = header.Values
+		}
+		if templateSource == "" {
+			continue
+		}
+
+		tpl, err := newTemplate().Parse(templateSource)
+		if err != nil {
+			logger.Log(logging.LevelError, "Invalid template for header %s: %s", header.Name, err.Error())
+			return nil, err
+		}
+
+		header.Template = tpl
 	}
 
 	// Per the OIDC/OAuth2 spec a redirect uri must match exactly. Wildcard matching is an

--- a/src/config.go
+++ b/src/config.go
@@ -183,6 +183,13 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 	logger.Log(logging.LevelDebug, "Scopes: %s", strings.Join(cfg.Scopes, ", "))
 	logger.Log(logging.LevelDebug, "SessionCookie: %v", cfg.SessionCookie)
 
+	switch cfg.Provider.TokenValidation {
+	case "AccessToken", "IdToken", "Introspection":
+	default:
+		logger.Log(logging.LevelError, "Invalid TokenValidation \"%s\". Must be one of AccessToken, IdToken or Introspection.", cfg.Provider.TokenValidation)
+		return nil, errors.New("invalid TokenValidation")
+	}
+
 	if cfg.Provider.TokenRenewalThreshold < 0.5 || cfg.Provider.TokenRenewalThreshold > 1.0 {
 		logger.Log(logging.LevelError, "Invalid TokenRenewalThreshold. The value must be >= 0.5 and <= 1.0.")
 		return nil, errors.New("invalid TokenRenewalThreshold")

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -3,11 +3,9 @@ package src
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
-	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
 func newTestConfig() *config.Config {
@@ -68,50 +66,5 @@ func TestNew_RejectsInvalidHeaderTemplate(t *testing.T) {
 
 	if _, err := New(context.Background(), http.NotFoundHandler(), cfg, "test"); err == nil {
 		t.Fatal("expected an invalid header template to be rejected")
-	}
-}
-
-func TestAttachHeaders_UsesThePreparsedTemplates(t *testing.T) {
-	cfg := newTestConfig()
-	cfg.Headers = []config.HeaderConfig{
-		{Name: "X-Subject", Value: "{{ .claims.sub }}"},
-		{Name: "X-Roles", Values: "{{ .claims.roles | mapToJsonArray }}"},
-		{Name: "X-Broken-Values", Values: "not a json array"},
-		{Name: "X-Empty"},
-	}
-
-	handler, err := New(context.Background(), http.NotFoundHandler(), cfg, "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	toa := handler.(*TraefikOidcAuth)
-
-	req := httptest.NewRequest("GET", "https://app.example.com/", nil)
-	req.Header.Set("X-Broken-Values", "spoofed")
-
-	claims := map[string]interface{}{
-		"sub":   "user-1",
-		"roles": []interface{}{"admin", "user"},
-	}
-
-	if err := toa.attachHeaders(req, &session.SessionState{}, claims, false, true); err != nil {
-		t.Fatal(err)
-	}
-
-	if got := req.Header.Get("X-Subject"); got != "user-1" {
-		t.Errorf("expected the rendered subject, got %q", got)
-	}
-
-	if got := req.Header.Values("X-Roles"); len(got) != 2 || got[0] != "admin" || got[1] != "user" {
-		t.Errorf("expected both roles as separate values, got %v", got)
-	}
-
-	if got := req.Header.Values("X-Broken-Values"); len(got) != 0 {
-		t.Errorf("expected a header whose values fail to render to be removed, got %v", got)
-	}
-
-	if _, ok := req.Header["X-Empty"]; !ok {
-		t.Error("expected a header without a value to still be set")
 	}
 }

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -1,0 +1,38 @@
+package src
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+)
+
+func newTestConfig() *config.Config {
+	cfg := CreateConfig()
+	cfg.Secret = "0123456789abcdef0123456789abcdef"
+	cfg.Provider.Url = "https://idp.example.com"
+	cfg.Provider.ClientId = "my-client"
+
+	return cfg
+}
+
+func TestNew_RejectsUnknownTokenValidation(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Provider.TokenValidation = "Nonsense"
+
+	if _, err := New(context.Background(), http.NotFoundHandler(), cfg, "test"); err == nil {
+		t.Fatal("expected an unknown TokenValidation to be rejected")
+	}
+}
+
+func TestNew_AcceptsKnownTokenValidation(t *testing.T) {
+	for _, tokenValidation := range []string{"AccessToken", "IdToken", "Introspection"} {
+		cfg := newTestConfig()
+		cfg.Provider.TokenValidation = tokenValidation
+
+		if _, err := New(context.Background(), http.NotFoundHandler(), cfg, "test"); err != nil {
+			t.Errorf("expected TokenValidation %s to be accepted, got %v", tokenValidation, err)
+		}
+	}
+}

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -3,9 +3,11 @@ package src
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
 func newTestConfig() *config.Config {
@@ -34,5 +36,82 @@ func TestNew_AcceptsKnownTokenValidation(t *testing.T) {
 		if _, err := New(context.Background(), http.NotFoundHandler(), cfg, "test"); err != nil {
 			t.Errorf("expected TokenValidation %s to be accepted, got %v", tokenValidation, err)
 		}
+	}
+}
+
+func TestNew_ParsesHeaderTemplatesUpfront(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Headers = []config.HeaderConfig{
+		{Name: "X-Subject", Value: "{{ .claims.sub }}"},
+		{Name: "X-Roles", Values: "{{ .claims.roles | mapToJsonArray }}"},
+		{Name: "X-Empty"},
+	}
+
+	if _, err := New(context.Background(), http.NotFoundHandler(), cfg, "test"); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Headers[0].Template == nil || cfg.Headers[1].Template == nil {
+		t.Error("expected the header templates to be parsed while loading the config")
+	}
+
+	if cfg.Headers[2].Template != nil {
+		t.Error("expected no template for a header without a value")
+	}
+}
+
+func TestNew_RejectsInvalidHeaderTemplate(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Headers = []config.HeaderConfig{
+		{Name: "X-Broken", Value: "{{ .claims.sub "},
+	}
+
+	if _, err := New(context.Background(), http.NotFoundHandler(), cfg, "test"); err == nil {
+		t.Fatal("expected an invalid header template to be rejected")
+	}
+}
+
+func TestAttachHeaders_UsesThePreparsedTemplates(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Headers = []config.HeaderConfig{
+		{Name: "X-Subject", Value: "{{ .claims.sub }}"},
+		{Name: "X-Roles", Values: "{{ .claims.roles | mapToJsonArray }}"},
+		{Name: "X-Broken-Values", Values: "not a json array"},
+		{Name: "X-Empty"},
+	}
+
+	handler, err := New(context.Background(), http.NotFoundHandler(), cfg, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	toa := handler.(*TraefikOidcAuth)
+
+	req := httptest.NewRequest("GET", "https://app.example.com/", nil)
+	req.Header.Set("X-Broken-Values", "spoofed")
+
+	claims := map[string]interface{}{
+		"sub":   "user-1",
+		"roles": []interface{}{"admin", "user"},
+	}
+
+	if err := toa.attachHeaders(req, &session.SessionState{}, claims, false, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := req.Header.Get("X-Subject"); got != "user-1" {
+		t.Errorf("expected the rendered subject, got %q", got)
+	}
+
+	if got := req.Header.Values("X-Roles"); len(got) != 2 || got[0] != "admin" || got[1] != "user" {
+		t.Errorf("expected both roles as separate values, got %v", got)
+	}
+
+	if got := req.Header.Values("X-Broken-Values"); len(got) != 0 {
+		t.Errorf("expected a header whose values fail to render to be removed, got %v", got)
+	}
+
+	if _, ok := req.Header["X-Empty"]; !ok {
+		t.Error("expected a header without a value to still be set")
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -364,15 +364,15 @@ func (toa *TraefikOidcAuth) handleCallback(rw http.ResponseWriter, req *http.Req
 
 		usedToken := ""
 
-		if toa.Config.Provider.TokenValidation == "AccessToken" {
+		switch toa.Config.Provider.TokenValidation {
+		case "AccessToken", "Introspection":
 			usedToken = token.AccessToken
-		} else if toa.Config.Provider.TokenValidation == "IdToken" {
+		case "IdToken":
 			usedToken = token.IdToken
-		} else if toa.Config.Provider.TokenValidation == "Introspection" {
-			usedToken = token.AccessToken
-		} else {
-			toa.logger.Log(logging.LevelError, "Invalid value '%s' for VerificationToken", toa.Config.Provider.TokenValidation)
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		default:
+			toa.logger.Log(logging.LevelError, "Invalid value '%s' for TokenValidation", toa.Config.Provider.TokenValidation)
+			http.Error(rw, "Invalid TokenValidation configuration", http.StatusInternalServerError)
+			return
 		}
 
 		redactedToken := usedToken

--- a/src/main.go
+++ b/src/main.go
@@ -375,6 +375,12 @@ func (toa *TraefikOidcAuth) handleCallback(rw http.ResponseWriter, req *http.Req
 			return
 		}
 
+		if usedToken == "" {
+			toa.logger.Log(logging.LevelError, "The identity provider didn't return an %s, which is required by TokenValidation '%s'. If you've customized the Scopes, make sure 'openid' is one of them.", validatedTokenName(toa.Config.Provider.TokenValidation), toa.Config.Provider.TokenValidation)
+			http.Error(rw, "Returned token is not valid", http.StatusInternalServerError)
+			return
+		}
+
 		redactedToken := usedToken
 		if len(redactedToken) > 16 {
 			redactedToken = redactedToken[0:16] + " *** REDACTED ***"

--- a/src/main.go
+++ b/src/main.go
@@ -267,17 +267,11 @@ func (toa *TraefikOidcAuth) attachHeaders(req *http.Request, session *session.Se
 				continue
 			}
 
+			if (header.Value != "" || header.Values != "") && header.Template == nil {
+				return fmt.Errorf("header %s has no parsed template", header.Name)
+			}
+
 			if header.Value != "" {
-				if header.Template == nil {
-					tpl, err := newTemplate().Parse(header.Value)
-
-					if err != nil {
-						return err
-					}
-
-					header.Template = tpl
-				}
-
 				var renderedValue bytes.Buffer
 				err := header.Template.Execute(&renderedValue, evalContext)
 
@@ -287,27 +281,21 @@ func (toa *TraefikOidcAuth) attachHeaders(req *http.Request, session *session.Se
 					req.Header.Set(header.Name, err.Error())
 				}
 			} else if header.Values != "" {
-				if header.Template == nil {
-					tpl, err := newTemplate().Parse(header.Values)
-
-					if err != nil {
-						return err
-					}
-
-					header.Template = tpl
-				}
-
 				var renderedValue bytes.Buffer
 				err := header.Template.Execute(&renderedValue, evalContext)
 
 				if err != nil {
-					req.Header.Set(header.Name, err.Error())
+					toa.logger.Log(logging.LevelError, "Failed to render the values of header %s: %s", header.Name, err.Error())
+					req.Header.Del(header.Name)
+					continue
 				}
 
 				var values []string
 				err = json.Unmarshal(renderedValue.Bytes(), &values)
 				if err != nil {
-					req.Header.Set(header.Name, err.Error())
+					toa.logger.Log(logging.LevelError, "The values of header %s didn't render to a json array: %s", header.Name, err.Error())
+					req.Header.Del(header.Name)
+					continue
 				}
 
 				if len(values) > 0 {

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -2,8 +2,14 @@ package src
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
 func TestTemplate_mapToJsonArray(t *testing.T) {
@@ -43,5 +49,50 @@ func TestTemplate_mapToJsonArray(t *testing.T) {
 
 	if result[2] != "prefix:123:suffix" {
 		t.Errorf("Expected prefix:123:suffix at index 2, got %s", result[2])
+	}
+}
+
+func TestAttachHeaders_UsesThePreparsedTemplates(t *testing.T) {
+	cfg := newTestConfig()
+	cfg.Headers = []config.HeaderConfig{
+		{Name: "X-Subject", Value: "{{ .claims.sub }}"},
+		{Name: "X-Roles", Values: "{{ .claims.roles | mapToJsonArray }}"},
+		{Name: "X-Broken-Values", Values: "not a json array"},
+		{Name: "X-Empty"},
+	}
+
+	handler, err := New(context.Background(), http.NotFoundHandler(), cfg, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	toa := handler.(*TraefikOidcAuth)
+
+	req := httptest.NewRequest("GET", "https://app.example.com/", nil)
+	req.Header.Set("X-Broken-Values", "spoofed")
+
+	claims := map[string]interface{}{
+		"sub":   "user-1",
+		"roles": []interface{}{"admin", "user"},
+	}
+
+	if err := toa.attachHeaders(req, &session.SessionState{}, claims, false, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := req.Header.Get("X-Subject"); got != "user-1" {
+		t.Errorf("expected the rendered subject, got %q", got)
+	}
+
+	if got := req.Header.Values("X-Roles"); len(got) != 2 || got[0] != "admin" || got[1] != "user" {
+		t.Errorf("expected both roles as separate values, got %v", got)
+	}
+
+	if got := req.Header.Values("X-Broken-Values"); len(got) != 0 {
+		t.Errorf("expected a header whose values fail to render to be removed, got %v", got)
+	}
+
+	if _, ok := req.Header["X-Empty"]; !ok {
+		t.Error("expected a header without a value to still be set")
 	}
 }

--- a/src/session.go
+++ b/src/session.go
@@ -197,6 +197,10 @@ func (toa *TraefikOidcAuth) validateToken(session *session.SessionState) (bool, 
 		}
 	}
 
+	if token == "" {
+		return false, nil, fmt.Errorf("the session contains no %s, which is required by TokenValidation '%s'", validatedTokenName(toa.Config.Provider.TokenValidation), toa.Config.Provider.TokenValidation)
+	}
+
 	if toa.Config.Provider.TokenValidation == "Introspection" {
 		return toa.introspectToken(token)
 	}
@@ -222,6 +226,14 @@ func (toa *TraefikOidcAuth) validateToken(session *session.SessionState) (bool, 
 	}
 
 	return ok, claims, err
+}
+
+func validatedTokenName(tokenValidation string) string {
+	if tokenValidation == "IdToken" {
+		return "id_token"
+	}
+
+	return "access_token"
 }
 
 func (toa *TraefikOidcAuth) storeSessionAndAttachCookie(session *session.SessionState, rw http.ResponseWriter) {

--- a/src/session_test.go
+++ b/src/session_test.go
@@ -1,6 +1,7 @@
 package src
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -48,5 +49,24 @@ func TestSessionIdpTokenExpiration(t *testing.T) {
 
 	if !expiresSoon {
 		t.Fail()
+	}
+}
+
+func TestValidateToken_MissingToken(t *testing.T) {
+	toa := &TraefikOidcAuth{
+		logger: logging.CreateLogger(logging.LevelError),
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{TokenValidation: "IdToken"},
+		},
+	}
+
+	ok, _, err := toa.validateToken(&session.SessionState{AccessToken: "only-an-access-token"})
+
+	if ok {
+		t.Fatal("expected a session without an id token to be rejected")
+	}
+
+	if err == nil || !strings.Contains(err.Error(), "id_token") {
+		t.Errorf("expected the error to name the missing token, got %v", err)
 	}
 }


### PR DESCRIPTION
Split out of #290, which is now a draft. Three commits. The theme is checking configuration when it's loaded rather than discovering it's wrong on a live request.

Related: #287.

## `fix: reject an unknown TokenValidation at startup`

An unknown `TokenValidation` value slipped through config load. It was only noticed in the callback, in an `else` branch that did `http.Error(rw, err.Error(), ...)` on an `err` that is nil at that point — so a typo in the config turned every completed login into a panic.

The value is checked while the config is loaded now, so the typo shows up in the traefik log at startup. The callback keeps a proper error path for it either way.

### Upgrade note

An invalid `TokenValidation` now fails middleware construction instead of every request, which takes the router to 503 for anyone currently misconfigured. Previously they'd have been seeing panics on the callback, so I don't think anyone is depending on the old behaviour, but it is a change in where the failure shows up.

## `fix: say which token the provider didn't return`

When a provider leaves out the token that `TokenValidation` selects, the only hint was

```
token is malformed: token contains an invalid number of segments
```

which sends people looking in the wrong place. #287 ran into it after Pocket ID started requiring the `openid` scope for an `id_token`. The error now names the missing token and mentions the scope, both at the callback and on later requests.

## `perf: parse the header templates once instead of per request`

`HeaderConfig` has a `Template` field to cache the parsed template, but `attachHeaders` ranges over the headers **by value**, so the parsed template was written to a copy and thrown away. Every configured header was re-parsed on every single request.

They're parsed while the config is loaded now, which also means a broken template shows up in the traefik log at startup instead of being rendered into an upstream header.

While in there: a `Values` template that fails to render, or renders something that isn't a json array, used to set the header to the error text and carry on, so the upstream service saw e.g. `X-Roles: invalid character 'n' looking for beginning of value`. The header is dropped and the reason logged instead. The json error no longer overwrites the template error before it either.

## Test plan

- New `src/config_test.go`: unknown/known `TokenValidation`, templates parsed at load, an invalid template rejected at load, and `attachHeaders` rendering from the pre-parsed templates including the broken-values case (which also checks a spoofed inbound `X-Broken-Values` header is removed rather than forwarded).
- The same code passed `go test -race ./...`, `go vet ./...`, `gofmt -l .` and `task test:e2e` (19/19 against Keycloak, so through Yaegi and not just the Go compiler) as part of #290. CI runs the unit tests on this branch.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. The upstream-header regression in the last commit was found by an adversarial review pass over my own earlier template change. I can explain and defend every line here.
