### PR TITLE
feat: add redis-based session storage

### DIFF
--- a/e2e/tests/keycloak/docker-compose.yml
+++ b/e2e/tests/keycloak/docker-compose.yml
@@ -1,4 +1,9 @@
 services:
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+
   keycloak:
     image: quay.io/keycloak/keycloak:26.2.5
     restart: unless-stopped

--- a/e2e/tests/keycloak/tests.spec.ts
+++ b/e2e/tests/keycloak/tests.spec.ts
@@ -123,6 +123,65 @@ test("logout", async ({ page }) => {
   expect(logoutResponse?.url()).toMatch(/http:\/\/localhost:8000\/realms\/master\/protocol\/openid-connect\/auth.*/);
 });
 
+test("login and logout using Redis session storage", async ({ page }) => {
+  await configureTraefik(`
+http:
+  services:
+    whoami:
+      loadBalancer:
+        servers:
+          - url: http://whoami:80
+
+  middlewares:
+    oidc-auth:
+      plugin:
+        traefik-oidc-auth:
+          LogLevel: DEBUG
+          Provider:
+            Url: "\${PROVIDER_URL_HTTP}"
+            ClientId: "\${CLIENT_ID}"
+            ClientSecret: "\${CLIENT_SECRET}"
+            UsePkce: false
+          SessionStorageType: Redis
+          Redis:
+            Address: "redis:6379"
+
+  routers:
+    whoami:
+      entryPoints: ["web"]
+      rule: "HostRegexp(\`.+\`)"
+      service: whoami
+      middlewares: ["oidc-auth@file"]
+`);
+
+  await expectGotoOkay(page, "http://localhost:9080");
+
+  const response = await login(page, "admin", "admin", "http://localhost:9080");
+
+  expect(response.status()).toBe(200);
+
+  // With Redis storage the cookie should only hold a short, opaque session id (a UUID), not the
+  // large encrypted blob Cookie storage would produce - this confirms Redis storage is actually
+  // in effect rather than the config being silently ignored.
+  const cookies = await page.context().cookies();
+  const sessionCookies = cookies.filter(c => c.name.startsWith("TraefikOidcAuth.Session"));
+
+  expect(sessionCookies).toHaveLength(1);
+  expect(sessionCookies[0].value).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+
+  const logoutResponse = await page.goto("http://localhost:9080/logout");
+
+  // After logout we should be at the login page again
+  expect(logoutResponse?.url()).toMatch(/http:\/\/localhost:8000\/realms\/master\/protocol\/openid-connect\/auth.*/);
+
+  // Logging back in should work too, proving the plugin can round-trip through Redis more than once.
+  await expectGotoOkay(page, "http://localhost:9080");
+
+  const secondLoginResponse = await login(page, "admin", "admin", "http://localhost:9080");
+
+  expect(secondLoginResponse.status()).toBe(200);
+});
+
 test("test two services is seamless", async ({ page }) => {
   await configureTraefik(`
 http:

--- a/src/config.go
+++ b/src/config.go
@@ -318,7 +318,7 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 		// non-zero MaxAge longer than the Redis TTL), the cookie may still be presented after its
 		// backing Redis entry was reaped for inactivity, forcing an unexpected re-login.
 		if cfg.SessionCookie != nil && cfg.SessionCookie.MaxAge > 0 && cfg.Redis.SessionTimeout > 0 && cfg.Redis.SessionTimeout < cfg.SessionCookie.MaxAge {
-			logger.Log(logging.LevelWarn, "Redis.SessionTimeout (%ds) is shorter than SessionCookie.MaxAge (%ds) -- the session cookie may outlive its backing Redis entry, forcing an unexpected re-login. Consider setting Redis.SessionTimeout to at least SessionCookie.MaxAge.", cfg.Redis.SessionTimeout, cfg.SessionCookie.MaxAge)
+			logger.Log(logging.LevelWarn, "Redis.SessionTimeout (%ds) is shorter than SessionCookie.MaxAge (%ds). The session cookie may outlive its backing Redis entry, forcing an unexpected re-login. Consider setting Redis.SessionTimeout to at least SessionCookie.MaxAge.", cfg.Redis.SessionTimeout, cfg.SessionCookie.MaxAge)
 		}
 		// Dialing happens lazily on first use, so a momentarily unreachable Redis doesn't fail
 		// plugin startup - errors surface per-request instead, same as any other session storage error.

--- a/src/config.go
+++ b/src/config.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,6 +44,7 @@ func CreateConfig() *config.Config {
 		LogoutUri:             "/logout",
 		PostLogoutRedirectUri: "/",
 		CookieNamePrefix:      "TraefikOidcAuth",
+		SessionStorageType:    config.SessionStorageTypeCookie,
 		SessionCookie: &config.SessionCookieConfig{
 			Path:     "/",
 			Domain:   "",
@@ -50,6 +52,13 @@ func CreateConfig() *config.Config {
 			HttpOnly: true,
 			SameSite: "default",
 			MaxAge:   0,
+		},
+		Redis: &config.RedisSessionStorageConfig{
+			Database:       0,
+			KeyPrefix:      "TraefikOidcAuth:Session:",
+			SessionTimeout: 86400, // 24h sliding TTL, refreshed on every session store/renewal
+			PoolSize:       10,
+			DialTimeout:    5,
 		},
 		AuthorizationHeader:     &config.AuthorizationHeaderConfig{},
 		AuthorizationCookie:     &config.AuthorizationCookieConfig{},
@@ -93,6 +102,21 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 	cfg.LogoutUri = utils.ExpandEnvironmentVariableString(cfg.LogoutUri)
 	cfg.PostLogoutRedirectUri = utils.ExpandEnvironmentVariableString(cfg.PostLogoutRedirectUri)
 	cfg.CookieNamePrefix = utils.ExpandEnvironmentVariableString(cfg.CookieNamePrefix)
+	cfg.SessionStorageType = utils.ExpandEnvironmentVariableString(cfg.SessionStorageType)
+	if cfg.Redis != nil {
+		cfg.Redis.Address = utils.ExpandEnvironmentVariableString(cfg.Redis.Address)
+		cfg.Redis.Username = utils.ExpandEnvironmentVariableString(cfg.Redis.Username)
+		cfg.Redis.Password = utils.ExpandEnvironmentVariableString(cfg.Redis.Password)
+		cfg.Redis.KeyPrefix = utils.ExpandEnvironmentVariableString(cfg.Redis.KeyPrefix)
+		cfg.Redis.TLSBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Redis.TLS, cfg.Redis.TLSBool)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Redis.InsecureSkipVerifyBool, err = utils.ExpandEnvironmentVariableBoolean(cfg.Redis.InsecureSkipVerify, cfg.Redis.InsecureSkipVerifyBool)
+		if err != nil {
+			return nil, err
+		}
+	}
 	cfg.UnauthenticatedBehavior = utils.ExpandEnvironmentVariableString(cfg.UnauthenticatedBehavior)
 	cfg.UnauthorizedBehavior = utils.ExpandEnvironmentVariableString(cfg.UnauthorizedBehavior)
 	cfg.BypassAuthenticationRule = utils.ExpandEnvironmentVariableString(cfg.BypassAuthenticationRule)
@@ -279,6 +303,31 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 		Transport: httpTransport,
 	}
 
+	var sessionStorage session.SessionStorage
+
+	switch cfg.SessionStorageType {
+	case "", config.SessionStorageTypeCookie:
+		sessionStorage = session.CreateCookieSessionStorage()
+	case config.SessionStorageTypeRedis:
+		if cfg.Redis == nil || cfg.Redis.Address == "" {
+			logger.Log(logging.LevelError, "SessionStorageType is Redis but Redis.Address is not configured")
+			return nil, errors.New("SessionStorageType is Redis but Redis.Address is not configured")
+		}
+		// Redis.SessionTimeout is a sliding idle timeout, refreshed on every StoreSession call, so
+		// an active session never actually hits it. But if the browser cookie can outlive it (a
+		// non-zero MaxAge longer than the Redis TTL), the cookie may still be presented after its
+		// backing Redis entry was reaped for inactivity, forcing an unexpected re-login.
+		if cfg.SessionCookie != nil && cfg.SessionCookie.MaxAge > 0 && cfg.Redis.SessionTimeout > 0 && cfg.Redis.SessionTimeout < cfg.SessionCookie.MaxAge {
+			logger.Log(logging.LevelWarn, "Redis.SessionTimeout (%ds) is shorter than SessionCookie.MaxAge (%ds) -- the session cookie may outlive its backing Redis entry, forcing an unexpected re-login. Consider setting Redis.SessionTimeout to at least SessionCookie.MaxAge.", cfg.Redis.SessionTimeout, cfg.SessionCookie.MaxAge)
+		}
+		// Dialing happens lazily on first use, so a momentarily unreachable Redis doesn't fail
+		// plugin startup - errors surface per-request instead, same as any other session storage error.
+		sessionStorage = session.CreateRedisSessionStorage(cfg.Redis)
+	default:
+		logger.Log(logging.LevelError, "Invalid SessionStorageType '%s'", cfg.SessionStorageType)
+		return nil, fmt.Errorf("invalid SessionStorageType '%s'", cfg.SessionStorageType)
+	}
+
 	logger.Log(logging.LevelInfo, "Configuration loaded successfully, starting OIDC Auth middleware...")
 
 	return &TraefikOidcAuth{
@@ -289,7 +338,7 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 		ClientJwtPrivateKey:         clientAssertionPrivateKey,
 		CallbackURL:                 parsedCallbackURL,
 		Config:                      cfg,
-		SessionStorage:              session.CreateCookieSessionStorage(),
+		SessionStorage:              sessionStorage,
 		BypassAuthenticationRule:    conditionalAuth,
 		RedirectUriWildcardsEnabled: redirectUriWildcardsEnabled,
 	}, nil

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -10,6 +10,7 @@ const DefaultSecret = "MLFs4TT99kOOq8h3UAVRtYoCTDYXiRcZ"
 
 const (
 	SessionStorageTypeCookie string = "Cookie"
+	SessionStorageTypeRedis  string = "Redis"
 )
 
 type Config struct {
@@ -37,7 +38,8 @@ type Config struct {
 	PostLogoutRedirectUri       string   `json:"post_logout_redirect_uri"`
 	ValidPostLogoutRedirectUris []string `json:"valid_post_logout_redirect_uris"`
 
-	SessionStorageType string `json:"session_storage_type"`
+	SessionStorageType string                     `json:"session_storage_type"`
+	Redis              *RedisSessionStorageConfig `json:"redis"`
 
 	CookieNamePrefix        string                     `json:"cookie_name_prefix"`
 	SessionCookie           *SessionCookieConfig       `json:"session_cookie"`
@@ -102,6 +104,37 @@ type SessionCookieConfig struct {
 	HttpOnly bool   `json:"http_only"`
 	SameSite string `json:"same_site"`
 	MaxAge   int    `json:"max_age"`
+}
+
+// RedisSessionStorageConfig configures the "Redis" SessionStorageType, which stores session
+// state server-side in Redis instead of embedding it in the session cookie. This is what makes
+// it safe to run multiple Traefik replicas with no shared memory - Cookie storage keeps every
+// replica's view of a session limited to whatever the browser sends back.
+type RedisSessionStorageConfig struct {
+	// host:port of the Redis server.
+	Address  string `json:"address"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Database int    `json:"database"`
+
+	TLS     string `json:"tls"`
+	TLSBool bool   `json:"tls_bool"`
+
+	InsecureSkipVerify     string `json:"insecure_skip_verify"`
+	InsecureSkipVerifyBool bool   `json:"insecure_skip_verify_bool"`
+
+	// Prefix prepended to every Redis key this middleware writes.
+	KeyPrefix string `json:"key_prefix"`
+
+	// TTL, in seconds, applied to a session's Redis entry every time it's (re-)stored. Acts as a
+	// sliding expiration: an active session keeps extending it, an abandoned one is reaped by Redis.
+	SessionTimeout int `json:"session_timeout"`
+
+	// Max number of pooled connections to Redis.
+	PoolSize int `json:"pool_size"`
+
+	// Timeout, in seconds, for establishing a new connection to Redis.
+	DialTimeout int `json:"dial_timeout"`
 }
 
 type AuthorizationHeaderConfig struct {

--- a/src/main.go
+++ b/src/main.go
@@ -465,6 +465,13 @@ func (toa *TraefikOidcAuth) handleCallback(rw http.ResponseWriter, req *http.Req
 func (toa *TraefikOidcAuth) handleLogout(rw http.ResponseWriter, req *http.Request, session *session.SessionState) {
 	toa.logger.Log(logging.LevelInfo, "Logging out...")
 
+	// Best-effort server-side revocation (a no-op for storage backends with no server-side
+	// state, e.g. Cookie). Logged but not fatal - don't block the user's logout on a transient
+	// storage error; the browser cookie itself is still cleared later, in handleCallback.
+	if err := toa.SessionStorage.ClearSession(toa.logger, toa.Config, session.Id); err != nil {
+		toa.logger.Log(logging.LevelWarn, "Failed to clear session from storage: %s", err.Error())
+	}
+
 	// https://openid.net/specs/openid-connect-rpinitiated-1_0.html
 
 	endSessionURL, err := url.Parse(toa.DiscoveryDocument.EndSessionEndpoint)

--- a/src/pkce_test.go
+++ b/src/pkce_test.go
@@ -161,6 +161,10 @@ func (m *memSessionStorage) TryGetSession(logger *logging.Logger, cfg *config.Co
 	return nil, nil
 }
 
+func (m *memSessionStorage) ClearSession(logger *logging.Logger, cfg *config.Config, sessionId string) error {
+	return nil
+}
+
 func newCallbackTestAuth(t *testing.T, usePkce bool, tokenURL, introspectURL string) *TraefikOidcAuth {
 	t.Helper()
 	toa := newPkceTestAuth(t)

--- a/src/redisclient/client.go
+++ b/src/redisclient/client.go
@@ -1,0 +1,138 @@
+// Package redisclient is a minimal, in-process, pure-Go Redis client. It is NOT a wrapper
+// around the redis-cli binary or any other subprocess - it opens its own net.Conn/tls.Conn TCP
+// socket and speaks the RESP2 wire protocol directly, the same way net/http speaks HTTP for the
+// OIDC provider calls elsewhere in this codebase.
+//
+// This exists because traefik-oidc-auth runs inside Traefik via yaegi (a Go interpreter), which
+// only supports pure-Go code built from its bundled stdlib symbol table - no cgo, no unsafe, no
+// large third-party dependency trees. The official redis/go-redis client can't be interpreted by
+// yaegi, so this package implements only the handful of commands session storage actually needs
+// (SET, GET, DEL, AUTH, SELECT, PING) using nothing but net, crypto/tls, bufio, strconv and
+// strings - packages already proven to work under yaegi elsewhere in this plugin.
+package redisclient
+
+import (
+	"strconv"
+	"time"
+)
+
+// Config configures a Pool of connections to a single Redis (or Redis-compatible) server.
+// There is no Sentinel/Cluster support - just one Address.
+type Config struct {
+	Address  string
+	Username string
+	Password string
+	Database int
+
+	UseTLS             bool
+	InsecureSkipVerify bool
+
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+
+	// PoolSize is the max number of connections kept idle in the pool. Checkouts beyond this
+	// still succeed - they just dial a fresh, unpooled connection.
+	PoolSize int
+}
+
+// Pool is a small, self-healing pool of persistent RESP2 connections to a single Redis server.
+// It dials lazily: no network I/O happens until the first command is issued, so constructing a
+// Pool can never fail or block on Redis being unreachable.
+type Pool struct {
+	cfg   Config
+	conns chan *conn
+}
+
+// NewPool constructs a Pool. It performs no network I/O.
+func NewPool(cfg Config) *Pool {
+	if cfg.PoolSize <= 0 {
+		cfg.PoolSize = 1
+	}
+	return &Pool{
+		cfg:   cfg,
+		conns: make(chan *conn, cfg.PoolSize),
+	}
+}
+
+// get checks out a pooled connection, or dials a new one if the pool is currently empty.
+func (p *Pool) get() (*conn, error) {
+	select {
+	case c := <-p.conns:
+		return c, nil
+	default:
+		return dial(p.cfg)
+	}
+}
+
+// put returns a healthy connection to the pool, or closes it if it's unhealthy or the pool is
+// already full. Never blocks.
+func (p *Pool) put(c *conn, healthy bool) {
+	if !healthy {
+		c.close()
+		return
+	}
+
+	select {
+	case p.conns <- c:
+	default:
+		c.close()
+	}
+}
+
+// withConn checks out a connection, runs fn, and returns the connection to the pool - or
+// discards it, so a broken connection is never reused - based on whether fn succeeded.
+func (p *Pool) withConn(fn func(c *conn) (reply, error)) (reply, error) {
+	c, err := p.get()
+	if err != nil {
+		return reply{}, err
+	}
+
+	r, err := fn(c)
+	p.put(c, err == nil)
+	return r, err
+}
+
+// Set stores value under key. A positive ttl sets an expiration (SET ... EX <seconds>); a
+// non-positive ttl stores the key with no expiration.
+func (p *Pool) Set(key, value string, ttl time.Duration) error {
+	args := []string{"SET", key, value}
+	if ttl > 0 {
+		args = append(args, "EX", strconv.Itoa(int(ttl.Seconds())))
+	}
+
+	_, err := p.withConn(func(c *conn) (reply, error) {
+		return c.do(args...)
+	})
+	return err
+}
+
+// Get retrieves the value stored under key. found is false, with no error, if key doesn't exist.
+func (p *Pool) Get(key string) (value string, found bool, err error) {
+	r, err := p.withConn(func(c *conn) (reply, error) {
+		return c.do("GET", key)
+	})
+	if err != nil {
+		return "", false, err
+	}
+	if r.isNil {
+		return "", false, nil
+	}
+	return r.str, true, nil
+}
+
+// Del removes key. It is not an error if key doesn't exist.
+func (p *Pool) Del(key string) error {
+	_, err := p.withConn(func(c *conn) (reply, error) {
+		return c.do("DEL", key)
+	})
+	return err
+}
+
+// Ping checks connectivity to the Redis server, dialing a connection if needed.
+func (p *Pool) Ping() error {
+	_, err := p.withConn(func(c *conn) (reply, error) {
+		return c.do("PING")
+	})
+	return err
+}

--- a/src/redisclient/client.go
+++ b/src/redisclient/client.go
@@ -1,12 +1,8 @@
-// Package redisclient is a minimal, in-process, pure-Go Redis client. It is NOT a wrapper
-// around the redis-cli binary or any other subprocess - it opens its own net.Conn/tls.Conn TCP
-// socket and speaks the RESP2 wire protocol directly, the same way net/http speaks HTTP for the
-// OIDC provider calls elsewhere in this codebase.
-//
+// Package redisclient is a minimal, pure-Go Redis client.
 // This exists because traefik-oidc-auth runs inside Traefik via yaegi (a Go interpreter), which
-// only supports pure-Go code built from its bundled stdlib symbol table - no cgo, no unsafe, no
-// large third-party dependency trees. The official redis/go-redis client can't be interpreted by
-// yaegi, so this package implements only the handful of commands session storage actually needs
+// only supports pure-Go code built from its bundled stdlib symbol table - no cgo, no unsafe, etc.
+// The official redis/go-redis client can't be interpreted by yaegi,
+// so this package implements only the handful of commands session storage actually needs
 // (SET, GET, DEL, AUTH, SELECT, PING) using nothing but net, crypto/tls, bufio, strconv and
 // strings - packages already proven to work under yaegi elsewhere in this plugin.
 package redisclient

--- a/src/redisclient/client_test.go
+++ b/src/redisclient/client_test.go
@@ -1,0 +1,288 @@
+package redisclient
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeRedisServer is a minimal in-process RESP2 server good enough to exercise the client
+// without a real Redis instance. It records every command it receives and replies according to
+// a simple in-memory key/value map, or a scripted response if one is queued.
+type fakeRedisServer struct {
+	t        *testing.T
+	listener net.Listener
+
+	mu       sync.Mutex
+	store    map[string]string
+	commands [][]string
+	authSeen bool
+	closeOn  string // if a command's first arg matches this, the connection is dropped instead of answered
+}
+
+func startFakeRedisServer(t *testing.T) *fakeRedisServer {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start fake redis server: %v", err)
+	}
+
+	s := &fakeRedisServer{t: t, listener: ln, store: map[string]string{}}
+
+	go s.acceptLoop()
+	t.Cleanup(func() { ln.Close() })
+
+	return s
+}
+
+func (s *fakeRedisServer) addr() string {
+	return s.listener.Addr().String()
+}
+
+func (s *fakeRedisServer) acceptLoop() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *fakeRedisServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	r := bufio.NewReader(conn)
+	w := bufio.NewWriter(conn)
+
+	for {
+		args, err := readCommand(r)
+		if err != nil {
+			return
+		}
+
+		s.mu.Lock()
+		s.commands = append(s.commands, args)
+		s.mu.Unlock()
+
+		if len(args) == 0 {
+			continue
+		}
+
+		if s.closeOn != "" && strings.EqualFold(args[0], s.closeOn) {
+			return
+		}
+
+		reply := s.handle(args)
+		if _, err := w.WriteString(reply); err != nil {
+			return
+		}
+		if err := w.Flush(); err != nil {
+			return
+		}
+	}
+}
+
+func (s *fakeRedisServer) handle(args []string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cmd := strings.ToUpper(args[0])
+	switch cmd {
+	case "AUTH":
+		s.authSeen = true
+		return "+OK\r\n"
+	case "SELECT":
+		return "+OK\r\n"
+	case "PING":
+		return "+PONG\r\n"
+	case "SET":
+		if len(args) < 3 {
+			return "-ERR wrong number of arguments\r\n"
+		}
+		s.store[args[1]] = args[2]
+		return "+OK\r\n"
+	case "GET":
+		val, ok := s.store[args[1]]
+		if !ok {
+			return "$-1\r\n"
+		}
+		return fmt.Sprintf("$%d\r\n%s\r\n", len(val), val)
+	case "DEL":
+		delete(s.store, args[1])
+		return ":1\r\n"
+	default:
+		return fmt.Sprintf("-ERR unknown command %q\r\n", cmd)
+	}
+}
+
+func (s *fakeRedisServer) receivedCommands() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]string, len(s.commands))
+	copy(out, s.commands)
+	return out
+}
+
+// readCommand decodes a single RESP2 array-of-bulk-strings command, the wire format writeCommand
+// produces - i.e. it's the server-side mirror of this package's own client encoding.
+func readCommand(r *bufio.Reader) ([]string, error) {
+	rep, err := readReply(r)
+	if err != nil {
+		return nil, err
+	}
+	if !rep.isArray {
+		return nil, fmt.Errorf("expected array, got %+v", rep)
+	}
+	args := make([]string, len(rep.array))
+	for i, item := range rep.array {
+		args[i] = item.str
+	}
+	return args, nil
+}
+
+func testConfig(addr string) Config {
+	return Config{
+		Address:      addr,
+		DialTimeout:  2 * time.Second,
+		ReadTimeout:  2 * time.Second,
+		WriteTimeout: 2 * time.Second,
+		PoolSize:     2,
+	}
+}
+
+func TestSetGetRoundTrip(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	pool := NewPool(testConfig(srv.addr()))
+
+	if err := pool.Set("k1", "v1", 0); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	val, found, err := pool.Get("k1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected key to be found")
+	}
+	if val != "v1" {
+		t.Fatalf("expected value %q, got %q", "v1", val)
+	}
+}
+
+func TestGetMiss(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	pool := NewPool(testConfig(srv.addr()))
+
+	_, found, err := pool.Get("missing")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if found {
+		t.Fatalf("expected key to not be found")
+	}
+}
+
+func TestDel(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	pool := NewPool(testConfig(srv.addr()))
+
+	_ = pool.Set("k1", "v1", 0)
+	if err := pool.Del("k1"); err != nil {
+		t.Fatalf("Del failed: %v", err)
+	}
+
+	_, found, _ := pool.Get("k1")
+	if found {
+		t.Fatalf("expected key to be gone after Del")
+	}
+}
+
+func TestSetWithTTLSendsExArg(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	pool := NewPool(testConfig(srv.addr()))
+
+	if err := pool.Set("k1", "v1", 30*time.Second); err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	found := false
+	for _, cmd := range srv.receivedCommands() {
+		if len(cmd) >= 5 && strings.EqualFold(cmd[0], "SET") && strings.EqualFold(cmd[3], "EX") && cmd[4] == "30" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a SET ... EX 30 command, got %v", srv.receivedCommands())
+	}
+}
+
+func TestAuthSentWhenCredentialsConfigured(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	cfg := testConfig(srv.addr())
+	cfg.Password = "secret"
+	pool := NewPool(cfg)
+
+	if err := pool.Ping(); err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+
+	srv.mu.Lock()
+	authSeen := srv.authSeen
+	srv.mu.Unlock()
+
+	if !authSeen {
+		t.Fatalf("expected an AUTH command to have been sent")
+	}
+}
+
+func TestNoAuthSentWithoutCredentials(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	pool := NewPool(testConfig(srv.addr()))
+
+	if err := pool.Ping(); err != nil {
+		t.Fatalf("Ping failed: %v", err)
+	}
+
+	srv.mu.Lock()
+	authSeen := srv.authSeen
+	srv.mu.Unlock()
+
+	if authSeen {
+		t.Fatalf("expected no AUTH command without configured credentials")
+	}
+}
+
+func TestConnectionErrorIsNotPooled(t *testing.T) {
+	srv := startFakeRedisServer(t)
+	srv.closeOn = "PING"
+	pool := NewPool(testConfig(srv.addr()))
+
+	if err := pool.Ping(); err == nil {
+		t.Fatalf("expected an error when the server drops the connection")
+	}
+
+	// A second call must dial a fresh connection rather than reuse a broken one.
+	srv.closeOn = ""
+	if err := pool.Ping(); err != nil {
+		t.Fatalf("expected the pool to recover with a fresh connection, got: %v", err)
+	}
+}
+
+func TestDialErrorOnUnreachableServer(t *testing.T) {
+	pool := NewPool(Config{
+		Address:     "127.0.0.1:1", // reserved, nothing listens here
+		DialTimeout: 200 * time.Millisecond,
+		PoolSize:    1,
+	})
+
+	if err := pool.Ping(); err == nil {
+		t.Fatalf("expected an error connecting to an unreachable address")
+	}
+}

--- a/src/redisclient/conn.go
+++ b/src/redisclient/conn.go
@@ -1,0 +1,106 @@
+package redisclient
+
+import (
+	"bufio"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// conn wraps a single, already-authenticated TCP (or TLS) connection to Redis, framed for RESP2.
+type conn struct {
+	nc  net.Conn
+	r   *bufio.Reader
+	w   *bufio.Writer
+	cfg Config
+}
+
+func dial(cfg Config) (*conn, error) {
+	dialer := &net.Dialer{Timeout: cfg.DialTimeout}
+
+	var nc net.Conn
+	var err error
+
+	if cfg.UseTLS {
+		tlsConfig := &tls.Config{InsecureSkipVerify: cfg.InsecureSkipVerify}
+		nc, err = tls.DialWithDialer(dialer, "tcp", cfg.Address, tlsConfig)
+	} else {
+		nc, err = dialer.Dial("tcp", cfg.Address)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("redis: failed to connect to %s: %w", cfg.Address, err)
+	}
+
+	c := &conn{
+		nc:  nc,
+		r:   bufio.NewReader(nc),
+		w:   bufio.NewWriter(nc),
+		cfg: cfg,
+	}
+
+	if err := c.authenticate(); err != nil {
+		nc.Close()
+		return nil, err
+	}
+
+	if cfg.Database != 0 {
+		if _, err := c.do("SELECT", strconv.Itoa(cfg.Database)); err != nil {
+			nc.Close()
+			return nil, fmt.Errorf("redis: SELECT %d failed: %w", cfg.Database, err)
+		}
+	}
+
+	return c, nil
+}
+
+func (c *conn) authenticate() error {
+	if c.cfg.Password == "" {
+		return nil
+	}
+
+	var err error
+	if c.cfg.Username != "" {
+		_, err = c.do("AUTH", c.cfg.Username, c.cfg.Password)
+	} else {
+		_, err = c.do("AUTH", c.cfg.Password)
+	}
+	if err != nil {
+		return fmt.Errorf("redis: AUTH failed: %w", err)
+	}
+	return nil
+}
+
+// do sends a command and returns its decoded reply. A RESP error reply is surfaced as a Go error.
+func (c *conn) do(args ...string) (reply, error) {
+	if err := c.setDeadline(); err != nil {
+		return reply{}, err
+	}
+	if err := writeCommand(c.w, args...); err != nil {
+		return reply{}, err
+	}
+	r, err := readReply(c.r)
+	if err != nil {
+		return reply{}, err
+	}
+	if r.isErr {
+		return reply{}, fmt.Errorf("redis: %s", r.str)
+	}
+	return r, nil
+}
+
+func (c *conn) setDeadline() error {
+	timeout := c.cfg.ReadTimeout
+	if c.cfg.WriteTimeout > timeout {
+		timeout = c.cfg.WriteTimeout
+	}
+	if timeout <= 0 {
+		return nil
+	}
+	return c.nc.SetDeadline(time.Now().Add(timeout))
+}
+
+func (c *conn) close() {
+	_ = c.nc.Close()
+}

--- a/src/redisclient/resp.go
+++ b/src/redisclient/resp.go
@@ -1,0 +1,95 @@
+package redisclient
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// reply is a decoded RESP2 reply. Only the subset of the protocol this client actually needs
+// (simple strings, errors, integers, bulk strings, arrays, and nils) is represented.
+type reply struct {
+	str     string
+	isNil   bool
+	isErr   bool
+	isArray bool
+	array   []reply
+}
+
+// writeCommand writes args as a RESP2 array of bulk strings - the standard way Redis clients
+// send commands - and flushes it.
+func writeCommand(w *bufio.Writer, args ...string) error {
+	if _, err := fmt.Fprintf(w, "*%d\r\n", len(args)); err != nil {
+		return err
+	}
+	for _, arg := range args {
+		if _, err := fmt.Fprintf(w, "$%d\r\n%s\r\n", len(arg), arg); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// readReply decodes a single RESP2 reply, recursing for arrays.
+func readReply(r *bufio.Reader) (reply, error) {
+	line, err := readLine(r)
+	if err != nil {
+		return reply{}, err
+	}
+	if len(line) == 0 {
+		return reply{}, fmt.Errorf("redis: received empty reply line")
+	}
+
+	prefix, body := line[0], line[1:]
+
+	switch prefix {
+	case '+': // simple string
+		return reply{str: body}, nil
+	case '-': // error
+		return reply{str: body, isErr: true}, nil
+	case ':': // integer
+		return reply{str: body}, nil
+	case '$': // bulk string
+		n, err := strconv.Atoi(body)
+		if err != nil {
+			return reply{}, fmt.Errorf("redis: invalid bulk string length %q: %w", body, err)
+		}
+		if n < 0 {
+			return reply{isNil: true}, nil
+		}
+		buf := make([]byte, n+2) // payload + trailing \r\n
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return reply{}, err
+		}
+		return reply{str: string(buf[:n])}, nil
+	case '*': // array
+		n, err := strconv.Atoi(body)
+		if err != nil {
+			return reply{}, fmt.Errorf("redis: invalid array length %q: %w", body, err)
+		}
+		if n < 0 {
+			return reply{isNil: true, isArray: true}, nil
+		}
+		items := make([]reply, n)
+		for i := 0; i < n; i++ {
+			item, err := readReply(r)
+			if err != nil {
+				return reply{}, err
+			}
+			items[i] = item
+		}
+		return reply{isArray: true, array: items}, nil
+	default:
+		return reply{}, fmt.Errorf("redis: unrecognized reply type %q", string(prefix))
+	}
+}
+
+func readLine(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}

--- a/src/session.go
+++ b/src/session.go
@@ -77,6 +77,13 @@ func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*session.Se
 	if err != nil {
 		return nil, false, claims, fmt.Errorf("failed to validate session ticket: %s", err.Error())
 	}
+	if session == nil {
+		// A storage backend may legitimately report "no session" without an error (eg. a Redis
+		// miss - the ticket doesn't error out because it's just an opaque id, not an encrypted
+		// blob whose decryption would fail). Callers of getSessionForRequest all key off err, so
+		// this has to surface as one, the same as every other "no usable session" case above.
+		return nil, false, claims, fmt.Errorf("no session found for the given session ticket")
+	}
 
 	if toa.logger.MinLevel == logging.LevelDebug {
 		tokenExpiresText := ""

--- a/src/session/cookieSessionStorage.go
+++ b/src/session/cookieSessionStorage.go
@@ -44,3 +44,9 @@ func (storage *CookieSessionStorage) TryGetSession(logger *logging.Logger, confi
 
 	return state, nil
 }
+
+// ClearSession is a no-op: the cookie itself IS the session state, there's nothing server-side
+// to delete. The caller is responsible for clearing the cookie.
+func (storage *CookieSessionStorage) ClearSession(logger *logging.Logger, config *config.Config, sessionId string) error {
+	return nil
+}

--- a/src/session/redisSessionStorage.go
+++ b/src/session/redisSessionStorage.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+	"github.com/sevensolutions/traefik-oidc-auth/src/redisclient"
+	"github.com/sevensolutions/traefik-oidc-auth/src/utils"
+)
+
+// redisClient is the subset of *redisclient.Pool this storage backend needs. Depending on this
+// small interface instead of the concrete type keeps RedisSessionStorage testable without a real
+// TCP connection.
+type redisClient interface {
+	Set(key, value string, ttl time.Duration) error
+	Get(key string) (value string, found bool, err error)
+	Del(key string) error
+}
+
+type RedisSessionStorage struct {
+	client    redisClient
+	keyPrefix string
+	ttl       time.Duration
+}
+
+func CreateRedisSessionStorage(cfg *config.RedisSessionStorageConfig) *RedisSessionStorage {
+	dialTimeout := time.Duration(cfg.DialTimeout) * time.Second
+	if dialTimeout <= 0 {
+		dialTimeout = 5 * time.Second
+	}
+
+	pool := redisclient.NewPool(redisclient.Config{
+		Address:            cfg.Address,
+		Username:           cfg.Username,
+		Password:           cfg.Password,
+		Database:           cfg.Database,
+		UseTLS:             cfg.TLSBool,
+		InsecureSkipVerify: cfg.InsecureSkipVerifyBool,
+		DialTimeout:        dialTimeout,
+		ReadTimeout:        dialTimeout,
+		WriteTimeout:       dialTimeout,
+		PoolSize:           cfg.PoolSize,
+	})
+
+	return &RedisSessionStorage{
+		client:    pool,
+		keyPrefix: cfg.KeyPrefix,
+		ttl:       time.Duration(cfg.SessionTimeout) * time.Second,
+	}
+}
+
+func (storage *RedisSessionStorage) StoreSession(logger *logging.Logger, config *config.Config, sessionId string, state *SessionState) (string, error) {
+	stateJson, _ := json.Marshal(*state)
+
+	encrypted, err := utils.Encrypt(string(stateJson), config.Secret)
+	if err != nil {
+		logger.Log(logging.LevelError, "Failed to encrypt session state: %s", err.Error())
+		return "", err
+	}
+
+	err = storage.client.Set(storage.key(sessionId), encrypted, storage.ttl)
+	if err != nil {
+		logger.Log(logging.LevelError, "Failed to store session in Redis: %s", err.Error())
+		return "", err
+	}
+
+	// Unlike CookieSessionStorage, the ticket handed back here is just the (already-random,
+	// unguessable) session id - the actual state lives in Redis, not in the cookie.
+	return sessionId, nil
+}
+
+func (storage *RedisSessionStorage) TryGetSession(logger *logging.Logger, config *config.Config, sessionTicket string) (*SessionState, error) {
+	encrypted, found, err := storage.client.Get(storage.key(sessionTicket))
+	if err != nil {
+		logger.Log(logging.LevelError, "Failed to read session from Redis: %s", err.Error())
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	plain, err := utils.Decrypt(encrypted, config.Secret)
+	if err != nil {
+		logger.Log(logging.LevelError, "Failed to decrypt session state: %s", err.Error())
+		return nil, err
+	}
+
+	state := &SessionState{}
+
+	err = json.Unmarshal([]byte(plain), state)
+	if err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+func (storage *RedisSessionStorage) ClearSession(logger *logging.Logger, config *config.Config, sessionId string) error {
+	err := storage.client.Del(storage.key(sessionId))
+	if err != nil {
+		logger.Log(logging.LevelError, "Failed to clear session from Redis: %s", err.Error())
+	}
+	return err
+}
+
+func (storage *RedisSessionStorage) key(sessionId string) string {
+	return storage.keyPrefix + sessionId
+}

--- a/src/session/redisSessionStorage_test.go
+++ b/src/session/redisSessionStorage_test.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sevensolutions/traefik-oidc-auth/src/config"
+	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+)
+
+// fakeRedisClient is an in-memory stand-in for redisClient, avoiding any real network I/O.
+type fakeRedisClient struct {
+	store map[string]string
+}
+
+func newFakeRedisClient() *fakeRedisClient {
+	return &fakeRedisClient{store: map[string]string{}}
+}
+
+func (f *fakeRedisClient) Set(key, value string, ttl time.Duration) error {
+	f.store[key] = value
+	return nil
+}
+
+func (f *fakeRedisClient) Get(key string) (string, bool, error) {
+	val, ok := f.store[key]
+	return val, ok, nil
+}
+
+func (f *fakeRedisClient) Del(key string) error {
+	delete(f.store, key)
+	return nil
+}
+
+func newTestRedisSessionStorage(client redisClient) (*RedisSessionStorage, *config.Config) {
+	storage := &RedisSessionStorage{
+		client:    client,
+		keyPrefix: "Test:Session:",
+		ttl:       time.Hour,
+	}
+	cfg := &config.Config{Secret: "01234567890123456789012345678901"} // 32 chars
+	return storage, cfg
+}
+
+func TestRedisSessionStorage_StoreThenRetrieve(t *testing.T) {
+	client := newFakeRedisClient()
+	storage, cfg := newTestRedisSessionStorage(client)
+	logger := logging.CreateLogger(logging.LevelDebug)
+
+	state := &SessionState{
+		Id:          "session-1",
+		AccessToken: "access-token",
+	}
+
+	ticket, err := storage.StoreSession(logger, cfg, state.Id, state)
+	if err != nil {
+		t.Fatalf("StoreSession failed: %v", err)
+	}
+	if ticket != state.Id {
+		t.Fatalf("expected ticket to be the bare session id %q, got %q", state.Id, ticket)
+	}
+
+	got, err := storage.TryGetSession(logger, cfg, ticket)
+	if err != nil {
+		t.Fatalf("TryGetSession failed: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected a session to be returned")
+	}
+	if got.AccessToken != state.AccessToken {
+		t.Fatalf("expected AccessToken %q, got %q", state.AccessToken, got.AccessToken)
+	}
+}
+
+func TestRedisSessionStorage_MissReturnsNilNil(t *testing.T) {
+	client := newFakeRedisClient()
+	storage, cfg := newTestRedisSessionStorage(client)
+	logger := logging.CreateLogger(logging.LevelDebug)
+
+	got, err := storage.TryGetSession(logger, cfg, "does-not-exist")
+	if err != nil {
+		t.Fatalf("expected no error on a miss, got: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil session on a miss, got: %+v", got)
+	}
+}
+
+func TestRedisSessionStorage_ClearSessionThenMiss(t *testing.T) {
+	client := newFakeRedisClient()
+	storage, cfg := newTestRedisSessionStorage(client)
+	logger := logging.CreateLogger(logging.LevelDebug)
+
+	state := &SessionState{Id: "session-1", AccessToken: "access-token"}
+	ticket, err := storage.StoreSession(logger, cfg, state.Id, state)
+	if err != nil {
+		t.Fatalf("StoreSession failed: %v", err)
+	}
+
+	if err := storage.ClearSession(logger, cfg, state.Id); err != nil {
+		t.Fatalf("ClearSession failed: %v", err)
+	}
+
+	got, err := storage.TryGetSession(logger, cfg, ticket)
+	if err != nil {
+		t.Fatalf("TryGetSession failed: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected the session to be gone after ClearSession, got: %+v", got)
+	}
+}
+
+func TestRedisSessionStorage_StoredValueIsEncrypted(t *testing.T) {
+	client := newFakeRedisClient()
+	storage, cfg := newTestRedisSessionStorage(client)
+	logger := logging.CreateLogger(logging.LevelDebug)
+
+	state := &SessionState{Id: "session-1", AccessToken: "super-secret-access-token"}
+	if _, err := storage.StoreSession(logger, cfg, state.Id, state); err != nil {
+		t.Fatalf("StoreSession failed: %v", err)
+	}
+
+	raw, ok := client.store[storage.keyPrefix+state.Id]
+	if !ok {
+		t.Fatalf("expected a value to be stored under the prefixed key")
+	}
+	if strings.Contains(raw, state.AccessToken) {
+		t.Fatalf("expected the stored value to be encrypted, but the plaintext access token was found in it")
+	}
+}

--- a/src/session/sessionStorage.go
+++ b/src/session/sessionStorage.go
@@ -11,6 +11,11 @@ import (
 type SessionStorage interface {
 	StoreSession(logger *logging.Logger, config *config.Config, sessionId string, state *SessionState) (string, error)
 	TryGetSession(logger *logging.Logger, config *config.Config, sessionTicket string) (*SessionState, error)
+
+	// ClearSession explicitly invalidates a session server-side, e.g. on logout. Storage
+	// backends with no server-side state (CookieSessionStorage) can no-op this - the caller is
+	// still responsible for clearing the browser cookie itself.
+	ClearSession(logger *logging.Logger, config *config.Config, sessionId string) error
 }
 
 type SessionState struct {

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -58,6 +58,8 @@ Provider:
 | `PostLogoutRedirectUri`* | no | `string` | `/` | The url where the user should be redirected after logout. |
 | `ValidPostLogoutRedirectUris` | no | `string[]` | *none* | A list of valid redirect uris when provided by the *redirect_uri* query parameter on the logout-endpoint. Per the OIDC/OAuth2 spec, the uri has to match exactly. Wildcards (including a single `*` matching anything) are an opt-in -- see [Redirect Uri Wildcards](#redirect-uri-wildcards) below. |
 | `CookieNamePrefix`* | no | `string` | `TraefikOidcAuth` | Specifies the prefix for all cookies used internally by the plugin. The final names are concatenated using dot-notation. Eg. `TraefikOidcAuth.Session`, `TraefikOidcAuth.CodeVerifier` etc. Please note that this prefix does not apply to *AuthorizationCookie* where the name can be set individually. |
+| `SessionStorageType`* | no | `string` | `Cookie` | Where session state is stored. `Cookie` (the default) encrypts the entire session into the cookie itself. `Redis` stores session state in Redis instead, keeping only a short opaque session id in the cookie. See [Redis](#redis-session-storage) below. |
+| `Redis` | no | [`Redis`](#redis-session-storage) | *none* | Redis session storage configuration, only used when `SessionStorageType` is `Redis`. See *Redis* block. |
 | `SessionCookie` | no | [`SessionCookie`](#session-cookie) | *none* | SessionCookie Configuration. See *SessionCookieConfig* block. |
 | `AuthorizationHeader` | no | [`AuthorizationHeader`](#authorization-header) | *none* | AuthorizationHeader Configuration. See *AuthorizationHeader* block. |
 | `AuthorizationCookie` | no | [`AuthorizationCookie`](#authorization-cookie) | *none* | AuthorizationCookie Configuration. See *AuthorizationCookie* block. |
@@ -126,6 +128,35 @@ When `CheckOnEveryRequest` is enabled, this will greatly increase the hit rate o
 | `HttpOnly` | no | `bool` | `true` | Whether the cookie should be marked http-only. |
 | `SameSite` | no | `string` | `default` | Can be one of `default`, `none`, `lax`, `strict`. |
 | `MaxAge` | no | `int` | `0` | Cookie time-to-live in seconds.  0 (default) is a ephemeral session cookie. |
+
+## Redis Block {#redis-session-storage}
+
+By default (`SessionStorageType: Cookie`), every replica's view of a session is limited to whatever the browser sends back in its cookie and there's no state shared between replicas. Setting `SessionStorageType: Redis` moves session state into Redis instead. The cookie shrinks to a short, opaque session id, and any Traefik replica that can reach the same Redis instance can serve any session. This is the recommended setup when running more than one Traefik replica.
+
+:::info
+This plugin runs inside Traefik via [yaegi](https://github.com/traefik/yaegi), a Go interpreter, which cannot load the official `redis` client library. Instead, a minimal, dependency-free Redis client is built into the plugin, implementing only the commands session storage needs (`SET`, `GET`, `DEL`, `AUTH`, `SELECT`, `PING`). A single Redis endpoint is supported. Redis Sentinel/Cluster setups are not supported yet.
+:::
+
+```yml
+SessionStorageType: Redis
+Redis:
+  Address: "redis:6379"
+  # Username: "default"
+  # Password: "${REDIS_PASSWORD}"
+```
+
+| Name | Required | Type | Default | Description |
+|---|---|---|---|---|
+| `Address`* | yes | `string` | *none* | The `host:port` of the Redis server. |
+| `Username`* | no | `string` | *none* | Username for Redis ACL authentication. Leave empty for password-only `AUTH`. |
+| `Password`* | no | `string` | *none* | Password for Redis authentication. Leave empty if your Redis server doesn't require authentication. |
+| `Database` | no | `int` | `0` | The numeric Redis database index (`SELECT`) to use. |
+| `TLS`* | no | `bool` | `false` | Connect to Redis over TLS. |
+| `InsecureSkipVerify`* | no | `bool` | `false` | Disables TLS certificate verification when `TLS` is enabled. Only recommended for quick testing. |
+| `KeyPrefix` | no | `string` | `TraefikOidcAuth:Session:` | Prefix prepended to every Redis key this plugin writes. |
+| `SessionTimeout` | no | `int` | `86400` (24h) | TTL, in seconds, applied to a session's Redis entry every time it's (re-)stored. This is a sliding expiration: an active session keeps extending it, an abandoned one is reaped by Redis on its own. If you set a non-zero [`SessionCookie.MaxAge`](#session-cookie), keep this value at least as large otherwise the browser can still present a cookie whose backing Redis entry was already reaped for inactivity, forcing an unexpected re-login. A startup warning is logged if it detects that case. |
+| `PoolSize` | no | `int` | `10` | Max number of pooled connections to Redis. |
+| `DialTimeout` | no | `int` | `5` | Timeout, in seconds, for establishing a new connection to Redis. |
 
 ## AuthorizationHeader Block {#authorization-header}
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -6,6 +6,7 @@ import {
   ListChecks,
   KeyRound,
   RefreshCw,
+  Database,
   ArrowUpFromLine,
   GitBranchPlus,
   FileWarning,
@@ -42,6 +43,13 @@ const FEATURES = [
     title: 'Token Auto-Renewal',
     description:
       'Tokens are transparently refreshed before they expire, keeping sessions alive without user interruption.',
+  },
+  {
+    Icon: Database,
+    color: '#14b8a6',
+    title: 'Redis Session Storage',
+    description:
+      'Store sessions in Redis instead of cookies to support multiple Traefik replicas.',
   },
   {
     Icon: ArrowUpFromLine,

--- a/workspaces/configs/http.yml
+++ b/workspaces/configs/http.yml
@@ -49,6 +49,9 @@ http:
           #ValidPostLoginRedirectUris: ["https://google.at"]
           #ValidPostLogoutRedirectUris: ["https://google.at"]
           #PostLoginRedirectUri: "/"
+          SessionStorageType: "Redis"
+          Redis:
+            Address: "redis:6379"
 
   routers:
     whoami:

--- a/workspaces/keycloak/docker-compose.yml
+++ b/workspaces/keycloak/docker-compose.yml
@@ -1,4 +1,9 @@
 services:
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+
   keycloak:
     image: quay.io/keycloak/keycloak:26.2.5
     restart: unless-stopped


### PR DESCRIPTION
WIP!

This PR adds support for Redis as a session storage to allow deploying traefik in a multi-replica setup.
It can also be used in situations where the session data get's really big and couldn't be stored in a cookie anymore.

Closes #87 