### PR TITLE
feat: add an opt-in ClockSkewTolerance for token validation

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -34,6 +34,7 @@ func CreateConfig() *config.Config {
 			ValidateAudienceBool:      true,
 			TokenValidation:           "IdToken",
 			TokenRenewalThreshold:     0.75,
+			ClockSkewTolerance:        0,
 			UseClaimsFromUserInfoBool: false,
 		},
 		// Note: It looks like we're not allowed to specify a default value for arrays here.
@@ -193,6 +194,11 @@ func New(uctx context.Context, next http.Handler, cfg *config.Config, name strin
 	if cfg.Provider.TokenRenewalThreshold < 0.5 || cfg.Provider.TokenRenewalThreshold > 1.0 {
 		logger.Log(logging.LevelError, "Invalid TokenRenewalThreshold. The value must be >= 0.5 and <= 1.0.")
 		return nil, errors.New("invalid TokenRenewalThreshold")
+	}
+
+	if cfg.Provider.ClockSkewTolerance < 0 || cfg.Provider.ClockSkewTolerance > 300 {
+		logger.Log(logging.LevelError, "Invalid ClockSkewTolerance. The value must be >= 0 and <= 300 seconds.")
+		return nil, errors.New("invalid ClockSkewTolerance")
 	}
 
 	var conditionalAuth *rules.RequestCondition

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -91,6 +91,8 @@ type ProviderConfig struct {
 
 	TokenRenewalThreshold float64 `json:"token_renewal_threshold"`
 
+	ClockSkewTolerance int `json:"clock_skew_tolerance"`
+
 	UseClaimsFromUserInfo     string `json:"use_claims_from_user_info"`
 	UseClaimsFromUserInfoBool bool   `json:"use_claims_from_user_info_bool"`
 }

--- a/src/oidc.go
+++ b/src/oidc.go
@@ -127,6 +127,10 @@ func exchangeAuthCode(oidcAuth *TraefikOidcAuth, req *http.Request, authCode str
 	return tokenResponse, nil
 }
 
+func (toa *TraefikOidcAuth) clockSkewTolerance() time.Duration {
+	return time.Duration(toa.Config.Provider.ClockSkewTolerance) * time.Second
+}
+
 func (toa *TraefikOidcAuth) validateTokenLocally(tokenString string) (bool, map[string]interface{}, error) {
 	claims := jwt.MapClaims{}
 
@@ -137,6 +141,7 @@ func (toa *TraefikOidcAuth) validateTokenLocally(tokenString string) (bool, map[
 
 	options := []jwt.ParserOption{
 		jwt.WithExpirationRequired(),
+		jwt.WithLeeway(toa.clockSkewTolerance()),
 	}
 
 	if toa.Config.Provider.ValidateIssuerBool {
@@ -350,7 +355,9 @@ func (toa *TraefikOidcAuth) getUserInfo(accessToken string, idTokenSubject strin
 			return nil, err
 		}
 
-		options := []jwt.ParserOption{}
+		options := []jwt.ParserOption{
+			jwt.WithLeeway(toa.clockSkewTolerance()),
+		}
 
 		if toa.Config.Provider.ValidateIssuerBool {
 			options = append(options, jwt.WithIssuer(toa.Config.Provider.ValidIssuer))

--- a/src/oidc_test.go
+++ b/src/oidc_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
@@ -453,4 +454,94 @@ func setupJWKS(t *testing.T, toa *TraefikOidcAuth, privateKey *rsa.PrivateKey) *
 
 	toa.Jwks.Url = jwksServer.URL
 	return jwksServer
+}
+
+func newClockSkewTest(t *testing.T, clockSkewTolerance int) (*TraefikOidcAuth, *rsa.PrivateKey) {
+	t.Helper()
+
+	privateKey, err := generateRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	toa := &TraefikOidcAuth{
+		logger: logging.CreateLogger(logging.LevelError),
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{ClockSkewTolerance: clockSkewTolerance},
+		},
+		httpClient: http.DefaultClient,
+		Jwks:       &oidc.JwksHandler{},
+	}
+
+	jwksServer := setupJWKS(t, toa, privateKey)
+	t.Cleanup(jwksServer.Close)
+
+	return toa, privateKey
+}
+
+func signTestToken(t *testing.T, privateKey *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-kid"
+
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return signedToken
+}
+
+func TestValidateTokenLocally_ToleratesClockSkew(t *testing.T) {
+	toa, privateKey := newClockSkewTest(t, 30)
+
+	now := time.Now()
+
+	notYetValid := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"nbf": now.Add(10 * time.Second).Unix(),
+		"iat": now.Add(10 * time.Second).Unix(),
+		"exp": now.Add(1 * time.Hour).Unix(),
+	})
+
+	ok, _, err := toa.validateTokenLocally(notYetValid)
+	if !ok || err != nil {
+		t.Errorf("expected a token from a slightly fast clock to be accepted, got %v", err)
+	}
+
+	justExpired := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"exp": now.Add(-10 * time.Second).Unix(),
+	})
+
+	ok, _, err = toa.validateTokenLocally(justExpired)
+	if !ok || err != nil {
+		t.Errorf("expected a token from a slightly slow clock to be accepted, got %v", err)
+	}
+}
+
+func TestValidateTokenLocally_RejectsBeyondClockSkew(t *testing.T) {
+	toa, privateKey := newClockSkewTest(t, 30)
+
+	now := time.Now()
+
+	notYetValid := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"nbf": now.Add(5 * time.Minute).Unix(),
+		"exp": now.Add(1 * time.Hour).Unix(),
+	})
+
+	if ok, _, _ := toa.validateTokenLocally(notYetValid); ok {
+		t.Error("expected a token that is not valid yet to be rejected")
+	}
+
+	expired := signTestToken(t, privateKey, jwt.MapClaims{
+		"sub": "12345",
+		"exp": now.Add(-5 * time.Minute).Unix(),
+	})
+
+	if ok, _, _ := toa.validateTokenLocally(expired); ok {
+		t.Error("expected an expired token to be rejected")
+	}
 }

--- a/website/docs/getting-started/middleware-configuration.md
+++ b/website/docs/getting-started/middleware-configuration.md
@@ -106,6 +106,7 @@ A path-only entry (without a scheme/host) only matches a path-only *redirect_uri
 | `TokenValidation`* | no | `string` | `IdToken` | Specifies which token or method should be used to validate the authentication cookie. Can be either `AccessToken`, `IdToken` or `Introspection`. `Introspection` may not work when using PKCE. |
 | `UseClaimsFromUserInfo`* | no | `bool` | `false` | When enabled, an additional request to the provider's `userinfo_endpoint` is made to validate the token and to retrieve additional claims. The userinfo claims are merged directly into the token claims, with userinfo values overriding token values for non-security-critical claims. |
 | `TokenRenewalThreshold` | no | `float` | `0.75` | The percentage of the token's lifetime after which it should be renewed before expiration. The value must be between 0.5 and 1.0. |
+| `ClockSkewTolerance` | no | `int` | `0` | How much clock difference between traefik and your provider is tolerated, in seconds, when the `exp` and `nbf` claims of a token are validated. The value must be between 0 and 300. Set this if you see *token is not valid yet* or *token is expired* errors even though both clocks look roughly correct. Note that it also delays the expiration of tokens by the same amount, so keep it just large enough to cover the drift you actually have. |
 
 :::warning
 When using `UseClaimsFromUserInfo`, an additional request to the provider's `userinfo_endpoint` is made to validate the token and to retrieve additional claims.


### PR DESCRIPTION
Split out of #294, as you asked. This is the half you said you want. The other commit is parked as a draft in #301.

Rebased on current `main`, so the conflict is gone.

Related: #236. Not auto-closed — the reporter still has to confirm the new option actually helps.

## The problem

A provider whose clock runs slightly ahead of traefik issues tokens with an `nbf` in the near future, which the parser rejects with *token is not valid yet* until the difference passes. That's #236.

## The change

`Provider.ClockSkewTolerance` (seconds, 0-300) is passed to the jwt parser as a leeway for `exp` and `nbf`, both when validating a token locally and when the `userinfo_endpoint` answers with a JWT.

**It defaults to `0`, so nothing changes unless you set it.** I went back and forth on this: most OIDC libraries default to 30-60s, and at `0` this only helps people who read the docs. But shipping a relaxed default would loosen token validation for everyone who upgrades without asking for it, and the tolerance also delays expiration by the same amount. Happy to flip it to `30` if you'd rather — it's a one-line change and the docs row already explains the trade-off.

## Test plan

- New tests: a clock skew within the tolerance is accepted, one beyond it is rejected, for both `nbf` and `exp`.
- `gofmt -l src`, `go vet ./...` and `go test -race ./...` pass on this branch.
- The workflow runs here are gated on your approval, so I ran both workflows on this exact commit (`b64746e`) inside my own fork: [Run Go tests](https://github.com/me-cedric/traefik-oidc-auth/actions/runs/33118159147) and [E2E Tests](https://github.com/me-cedric/traefik-oidc-auth/actions/runs/33118159152) both pass. That covers Yaegi, not just the Go compiler.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. I can explain and defend every line here.
