### PR TITLE
fix: only drop the session when the provider rejects the refresh token

### DIFF
--- a/src/oidc.go
+++ b/src/oidc.go
@@ -249,6 +249,8 @@ func (toa *TraefikOidcAuth) introspectToken(token string) (bool, map[string]inte
 	}
 }
 
+var errRefreshTokenRejected = errors.New("the provider rejected the refresh token")
+
 func (toa *TraefikOidcAuth) renewToken(refreshToken string) (*oidc.OidcTokenResponse, error) {
 	urlValues := url.Values{
 		"grant_type":    {"refresh_token"},
@@ -272,7 +274,12 @@ func (toa *TraefikOidcAuth) renewToken(refreshToken string) (*oidc.OidcTokenResp
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		toa.logger.Log(logging.LevelError, "renewToken: received bad HTTP response from Provider: %s", string(body))
+		toa.logger.Log(logging.LevelError, "renewToken: received bad HTTP response from Provider (Status: %d): %s", resp.StatusCode, string(body))
+
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return nil, errRefreshTokenRejected
+		}
+
 		return nil, errors.New("invalid status code")
 	}
 

--- a/src/session.go
+++ b/src/session.go
@@ -16,6 +16,8 @@ import (
 var errNoSessionCookie = errors.New("no session cookie is present")
 var errNoSession = errors.New("no session was found for the session ticket")
 
+const renewalRetryInterval = 30 * time.Second
+
 func (toa *TraefikOidcAuth) getSessionForRequest(req *http.Request) (*session.SessionState, bool, map[string]interface{}, error) {
 	// Use AuthorizationHeader, if present
 	if toa.Config.AuthorizationHeader != nil && toa.Config.AuthorizationHeader.Name != "" {
@@ -121,15 +123,28 @@ func validateSessionTicket(toa *TraefikOidcAuth, sessionTicket string) (*session
 	}
 
 	if !success || err != nil || idpTokenExpiresSoon {
+		renewalIsOptional := success && err == nil
+
+		if renewalIsOptional && renewalFailedRecently(session) {
+			return session, claims, nil, nil
+		}
+
 		if session.RefreshToken != "" {
 			toa.logger.Log(logging.LevelInfo, "Trying to renew tokens...")
 
-			newTokens, err := toa.renewToken(session.RefreshToken)
+			newTokens, renewErr := toa.renewToken(session.RefreshToken)
 
-			if err != nil {
-				return nil, nil, nil, err
+			if renewErr != nil {
+				if renewalIsOptional && renewErr != errRefreshTokenRejected {
+					toa.logger.Log(logging.LevelWarn, "Failed to renew the tokens before they expire, continuing with the current session: %s", renewErr.Error())
+					session.RenewalFailedAt = time.Now()
+					return session, claims, session, nil
+				}
+
+				return nil, nil, nil, renewErr
 			}
 
+			session.RenewalFailedAt = time.Time{}
 			session.AccessToken = newTokens.AccessToken
 
 			if newTokens.RefreshToken != "" {
@@ -173,6 +188,14 @@ func validateSessionTicket(toa *TraefikOidcAuth, sessionTicket string) (*session
 	}
 
 	return session, claims, nil, nil
+}
+
+func renewalFailedRecently(session *session.SessionState) bool {
+	if session.RenewalFailedAt.IsZero() {
+		return false
+	}
+
+	return time.Since(session.RenewalFailedAt) < renewalRetryInterval
 }
 
 func checkIdpTokenExpiresSoon(toa *TraefikOidcAuth, session *session.SessionState) bool {

--- a/src/session/sessionStorage.go
+++ b/src/session/sessionStorage.go
@@ -22,6 +22,8 @@ type SessionState struct {
 	IsAuthorized   bool      `json:"is_authorized"`
 	TokenExpiresIn int       `json:"token_expires_in"`
 
+	RenewalFailedAt time.Time `json:"renewal_failed_at"`
+
 	// Set when this session was (re-)established via a redirect triggered by UnauthorizedBehavior's
 	// Challenge, regardless of whether the resulting session ends up authorized - the callback may be
 	// handled by a different, more permissive middleware instance than the one that failed the check.

--- a/src/session_test.go
+++ b/src/session_test.go
@@ -1,12 +1,18 @@
 package src
 
 import (
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/sevensolutions/traefik-oidc-auth/src/config"
 	"github.com/sevensolutions/traefik-oidc-auth/src/logging"
+	"github.com/sevensolutions/traefik-oidc-auth/src/oidc"
 	"github.com/sevensolutions/traefik-oidc-auth/src/session"
 )
 
@@ -68,5 +74,175 @@ func TestValidateToken_MissingToken(t *testing.T) {
 
 	if err == nil || !strings.Contains(err.Error(), "id_token") {
 		t.Errorf("expected the error to name the missing token, got %v", err)
+	}
+}
+
+type fixedSessionStorage struct {
+	state *session.SessionState
+}
+
+func (s *fixedSessionStorage) StoreSession(logger *logging.Logger, cfg *config.Config, sessionId string, state *session.SessionState) (string, error) {
+	return "ticket", nil
+}
+
+func (s *fixedSessionStorage) TryGetSession(logger *logging.Logger, cfg *config.Config, sessionTicket string) (*session.SessionState, error) {
+	return s.state, nil
+}
+
+func newRenewalTest(t *testing.T, tokenIsActive bool) *TraefikOidcAuth {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/introspect", func(rw http.ResponseWriter, req *http.Request) {
+		json.NewEncoder(rw).Encode(map[string]interface{}{"active": tokenIsActive, "sub": "user-1"})
+	})
+	mux.HandleFunc("/token", func(rw http.ResponseWriter, req *http.Request) {
+		http.Error(rw, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	state := &session.SessionState{
+		Id:             "session-1",
+		AccessToken:    "current-access-token",
+		RefreshToken:   "current-refresh-token",
+		RefreshedAt:    time.Now().Add(-50 * time.Second),
+		TokenExpiresIn: 60,
+	}
+
+	toa := &TraefikOidcAuth{
+		logger:     logging.CreateLogger(logging.LevelError),
+		httpClient: server.Client(),
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{
+				TokenValidation:       "Introspection",
+				TokenRenewalThreshold: 0.75,
+			},
+		},
+		SessionStorage: &fixedSessionStorage{state: state},
+		DiscoveryDocument: &oidc.OidcDiscovery{
+			IntrospectionEndpoint: server.URL + "/introspect",
+			TokenEndpoint:         server.URL + "/token",
+		},
+	}
+
+	return toa
+}
+
+// Duplicated from oidc_test.go in #300 so this branch stands alone. Drop it once #300 merges.
+func signTestToken(t *testing.T, privateKey *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-kid"
+
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return signedToken
+}
+
+func newLocalValidationRenewalTest(t *testing.T, renewalStatusCode int) (*TraefikOidcAuth, *session.SessionState, *int) {
+	t.Helper()
+
+	privateKey, err := generateRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renewalAttempts := 0
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		renewalAttempts++
+		http.Error(rw, `{"error":"invalid_grant"}`, renewalStatusCode)
+	}))
+	t.Cleanup(tokenServer.Close)
+
+	state := &session.SessionState{
+		Id:             "session-1",
+		AccessToken:    signTestToken(t, privateKey, jwt.MapClaims{"sub": "user-1", "exp": time.Now().Add(10 * time.Minute).Unix()}),
+		RefreshToken:   "current-refresh-token",
+		RefreshedAt:    time.Now().Add(-50 * time.Second),
+		TokenExpiresIn: 60,
+	}
+
+	toa := &TraefikOidcAuth{
+		logger:     logging.CreateLogger(logging.LevelError),
+		httpClient: http.DefaultClient,
+		Config: &config.Config{
+			Provider: &config.ProviderConfig{
+				TokenValidation:       "AccessToken",
+				TokenRenewalThreshold: 0.75,
+			},
+		},
+		SessionStorage:    &fixedSessionStorage{state: state},
+		Jwks:              &oidc.JwksHandler{},
+		DiscoveryDocument: &oidc.OidcDiscovery{TokenEndpoint: tokenServer.URL},
+	}
+
+	jwksServer := setupJWKS(t, toa, privateKey)
+	t.Cleanup(jwksServer.Close)
+
+	return toa, state, &renewalAttempts
+}
+
+func TestValidateSessionTicket_KeepsSessionWhenRenewalFailsTemporarily(t *testing.T) {
+	toa, _, renewalAttempts := newLocalValidationRenewalTest(t, http.StatusInternalServerError)
+
+	sessionState, _, updatedSession, err := validateSessionTicket(toa, "ticket")
+
+	if err != nil {
+		t.Fatalf("expected a temporary renewal failure to keep the session, got %v", err)
+	}
+
+	if sessionState == nil {
+		t.Fatal("expected the current session to be kept")
+	}
+
+	if updatedSession == nil || updatedSession.RenewalFailedAt.IsZero() {
+		t.Error("expected the failed renewal to be recorded on the session")
+	}
+
+	if *renewalAttempts != 1 {
+		t.Errorf("expected one renewal attempt, got %d", *renewalAttempts)
+	}
+
+	if _, _, _, err := validateSessionTicket(toa, "ticket"); err != nil {
+		t.Fatalf("expected the session to still be usable, got %v", err)
+	}
+
+	if *renewalAttempts != 1 {
+		t.Errorf("expected the renewal not to be retried on the next request, got %d attempts", *renewalAttempts)
+	}
+}
+
+func TestValidateSessionTicket_DropsSessionWhenRefreshTokenIsRejected(t *testing.T) {
+	toa, _, _ := newLocalValidationRenewalTest(t, http.StatusBadRequest)
+
+	sessionState, _, _, err := validateSessionTicket(toa, "ticket")
+
+	if err == nil {
+		t.Fatal("expected a rejected refresh token to end the session")
+	}
+
+	if sessionState != nil {
+		t.Errorf("expected no session, got %v", sessionState)
+	}
+}
+
+func TestValidateSessionTicket_FailsWhenRenewalFailsForAnExpiredToken(t *testing.T) {
+	toa := newRenewalTest(t, false)
+
+	sessionState, _, _, err := validateSessionTicket(toa, "ticket")
+
+	if err == nil {
+		t.Fatal("expected an error when the token is no longer valid and cannot be renewed")
+	}
+
+	if sessionState != nil {
+		t.Errorf("expected no session, got %v", sessionState)
 	}
 }


### PR DESCRIPTION
The other half of #294, split out as you asked. **Draft on purpose** — I'm not asking you to merge this.

You're right that it's theoretical. It wasn't an issue for me personally; a sweep I did flagged it as a possible one. I'm parking it here so it exists somewhere if an issue later turns out to match, and so @cstack89 can test it against #257 on its own branch without it blocking #300.

**No claim that this fixes #257.** Rebased on current `main`.

## What it does

Tokens are renewed once they reach `TokenRenewalThreshold` (0.75 by default) of their lifetime, so the current one is normally still valid at that point. A failing refresh drops the session anyway and bounces the user to the IDP: the page breaks, and a reload logs you straight back in. That shape matches what #257 describes.

If the current token still validates, a failed renewal is now logged and the request continues with it.

Keeping the session on *any* failed renewal would be too generous though. `renewToken` returned the same opaque error for a 502 and for a 400 `invalid_grant`, so a refresh token the provider deliberately rejected — revoked, logged out at the IDP, account disabled — would keep the old tokens working until they expire, up to 25% of their lifetime. A 4xx from the token endpoint (except 429) is now a definitive rejection and ends the session as before, so revocation still takes effect promptly.

## The cookie-size cost you asked about

The failed attempt is recorded on the session as `RenewalFailedAt time.Time` so a struggling IDP doesn't get one POST per request for the rest of the token's lifetime. That is one extra RFC 3339 timestamp in the session JSON, about 35 bytes before encryption, and it is only non-zero after a renewal actually fails.

If that is still too much, the same debounce could be done with an in-memory map keyed by session id instead of a session field. It would be lost on restart and not shared between traefik instances, which is acceptable for a 30s backoff. Say the word and I'll switch it.

## Test plan

- New tests: a temporary failure (500) keeps the session, records the attempt and doesn't retry on the next request; a 400 ends it; an expired token that can't be renewed still fails.
- `gofmt -l src`, `go vet ./...` and `go test -race ./...` pass on this branch.
- Ran both workflows on this exact commit (`f133481`) in my own fork so you don't have to approve runs on a draft: [Run Go tests](https://github.com/me-cedric/traefik-oidc-auth/actions/runs/33118161892) and [E2E Tests](https://github.com/me-cedric/traefik-oidc-auth/actions/runs/33118161674) both pass.

## Note for whoever picks this up

`src/session_test.go` here carries its own copy of the `signTestToken` helper, because #300 adds that helper to `src/oidc_test.go` and this branch has to compile standalone. The duplicate goes away when this is rebased after #300 merges. It's marked with a comment.

## AI usage

Per `AI_POLICY.md`: written with Claude Opus 5 (Claude Code), then reviewed line by line. The revoked-refresh-token hole in the first version of this came out of an adversarial security review pass. I can explain and defend every line here.
